### PR TITLE
WP-5430 Add special message when depending on the analyzer package but not us…

### DIFF
--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -173,7 +173,8 @@ void run({List<String> ignoredPackages = const []}) {
             ..remove(dependencyValidatorPackageName);
 
   if (unusedDependencies.contains('analyzer')) {
-    logger.warning('You do not need to depend on the analyzer to run the dart analyzer.');
+    logger.warning('''You do not need to depend on `analyzer` to run the Dart analyzer.
+        Instead, just run the `dartanalyzer` executable that is bundled with the Dart SDK.''');
   }
 
   unusedDependencies

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -173,8 +173,10 @@ void run({List<String> ignoredPackages = const []}) {
             ..remove(dependencyValidatorPackageName);
 
   if (unusedDependencies.contains('analyzer')) {
-    logger.warning('''You do not need to depend on `analyzer` to run the Dart analyzer.
-        Instead, just run the `dartanalyzer` executable that is bundled with the Dart SDK.''');
+    logger.warning(
+      'You do not need to depend on `analyzer` to run the Dart analyzer.\n'
+          'Instead, just run the `dartanalyzer` executable that is bundled with the Dart SDK.',
+    );
   }
 
   unusedDependencies

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -170,9 +170,15 @@ void run({List<String> ignoredPackages = const []}) {
           // Remove all deps being used for their transformer(s)
           .difference(packagesUsedViaTransformers)
             // Remove this package, since we know they're using our executable
-            ..remove(dependencyValidatorPackageName)
-            // Ignore known unused packages
-            ..removeAll(ignoredPackages);
+            ..remove(dependencyValidatorPackageName);
+
+  if (unusedDependencies.contains('analyzer')) {
+    logger.warning('You do not need to depend on the analyzer to run the dart analyzer.');
+  }
+
+  unusedDependencies
+    // Ignore known unused packages
+    ..removeAll(ignoredPackages);
 
   if (unusedDependencies.isNotEmpty) {
     logDependencyInfractions(

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -73,6 +73,13 @@ void main() {
       expect(result.stderr, contains('dart_dev'));
     });
 
+    test('warns when the analyzer pacakge is ', () {
+      final result = checkProject(projectWithNoProblems);
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('No infractions found, valid is good to go!'));
+    });
+
     test('passes when all dependencies are used and valid', () {
       final result = checkProject(projectWithNoProblems);
 

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -22,6 +22,7 @@ const String projectWithMissingDeps = 'test_fixtures/missing';
 const String projectWithOverPromotedDeps = 'test_fixtures/over_promoted';
 const String projectWithUnderPromotedDeps = 'test_fixtures/under_promoted';
 const String projectWithUnusedDeps = 'test_fixtures/unused';
+const String projectWithAnalyzer = 'test_fixtures/analyzer';
 const String projectWithNoProblems = 'test_fixtures/valid';
 
 ProcessResult checkProject(String projectPath, {List<String> ignoredPackages = const []}) {
@@ -73,11 +74,11 @@ void main() {
       expect(result.stderr, contains('dart_dev'));
     });
 
-    test('warns when the analyzer pacakge is ', () {
-      final result = checkProject(projectWithNoProblems);
+    test('warns when the analyzer pacakge is depended on but not used', () {
+      final result = checkProject(projectWithAnalyzer, ignoredPackages: ['analyzer']);
 
       expect(result.exitCode, 0);
-      expect(result.stdout, contains('No infractions found, valid is good to go!'));
+      expect(result.stderr, contains('You do not need to depend on `analyzer` to run the Dart analyzer.'));
     });
 
     test('passes when all dependencies are used and valid', () {

--- a/test_fixtures/analyzer/lib/analyzer_dep.dart
+++ b/test_fixtures/analyzer/lib/analyzer_dep.dart
@@ -1,0 +1,13 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/test_fixtures/analyzer/pubpsec.yaml
+++ b/test_fixtures/analyzer/pubpsec.yaml
@@ -1,0 +1,6 @@
+name: analyzer_dep
+version: 0.0.0
+private: true
+
+dependencies:
+  analyzer: any

--- a/test_fixtures/analyzer/pubspec.yaml
+++ b/test_fixtures/analyzer/pubspec.yaml
@@ -4,3 +4,7 @@ private: true
 
 dependencies:
   analyzer: any
+
+dev_dependencies:
+  dependency_validator:
+    path: ../..


### PR DESCRIPTION
## Ultimate Problem
- There were some cases before when packages were declaring `analyzer` as a dependency because they thought it was necessary to run the analyzer cli. This would cause unnecessary dependency locking.

## Solution
- Add a special message calling out that behavior
  - Don't throw, because that would be breaking, also we can't be sure that's what's happening.

## Testing Suggestions
- Verify tests pass

## Possible Areas of Regression
- N/A

---
FYA: @evanweible-wf @maxwellpeterson-wf @jayudey-wf 
FYI: @greglittlefield-wf 