### PR TITLE
WP-6077: Add flags to control when the executable fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ dev_dependencies:
 This package comes with a single executable: dependency_validator. To run this executable: `pub run dependency_validator`. This usage will run the tool and report any missing, under-promoted, over-promoted, and unused dependencies.
 
 - Missing: When a dependency is used in the package but not declared in the `pubspec.yaml`
+  - Optionaly do not fail by using the `--no-fatal-missing` flag.
 - Under-promoted: When a dependency is used within `lib/` but only declared as a dev_dependency.
+  - Optionaly do not fail by using the `--no-fatal-under-promoted` flag.
 - Over-promoted: When a dependency is only used outside `lib/` but declared as a dependency.
+  - Optionaly do not fail by using the `--no-fatal-over-promoted` flag.
 - Unused: When a dependency is not used in the package but declared in the `pubspec.yaml`.
+  - Optionaly do not fail by using the `--no-fatal-unused` flag.
   - Some packages are not imported by any dart files but are used for their executables. If that is the case they can be white-listed by using the `--ignore` option.
 
   ```bash

--- a/bin/dependency_validator.dart
+++ b/bin/dependency_validator.dart
@@ -20,7 +20,12 @@ import 'package:dependency_validator/dependency_validator.dart';
 
 final ArgParser argParser = new ArgParser()
   ..addFlag('verbose', defaultsTo: false)
-  ..addOption('ignore', abbr: 'i', allowMultiple: true, splitCommas: true);
+  ..addOption('ignore', abbr: 'i', allowMultiple: true, splitCommas: true)
+  ..addFlag('fatal-under-promoted', defaultsTo: true)
+  ..addFlag('fatal-over-promoted', defaultsTo: true)
+  ..addFlag('fatal-missing', defaultsTo: true)
+  ..addFlag('fatal-dev-missing', defaultsTo: true)
+  ..addFlag('fatal-unused', defaultsTo: true);
 
 void main(List<String> args) {
   final argResults = argParser.parse(args);
@@ -28,6 +33,12 @@ void main(List<String> args) {
   if (argResults.wasParsed('verbose') && argResults['verbose']) {
     Logger.root.level = Level.ALL;
   }
+
+  final fatalUnderPromoted = argResults['fatal-under-promoted'] ?? true;
+  final fatalOverPromoted = argResults['fatal-over-promoted'] ?? true;
+  final fatalMissing = argResults['fatal-missing'] ?? true;
+  final fatalDevMissing = argResults['fatal-dev-missing'] ?? true;
+  final fatalUnused = argResults['fatal-unused'] ?? true;
 
   List<String> ignoredPackages;
 
@@ -45,5 +56,13 @@ void main(List<String> args) {
       .where((record) => record.level >= Level.WARNING)
       .map((record) => record.message)
       .listen(stderr.writeln);
-  run(ignoredPackages: ignoredPackages);
+
+  run(
+    ignoredPackages: ignoredPackages,
+    fatalUnderPromoted: fatalUnderPromoted,
+    fatalOverPromoted: fatalOverPromoted,
+    fatalMissing: fatalMissing,
+    fatalDevMissing: fatalDevMissing,
+    fatalUnused: fatalUnused,
+  );
 }

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -19,7 +19,14 @@ import 'package:yaml/yaml.dart';
 import './src/utils.dart';
 
 /// Check for missing, under-promoted, over-promoted, and unused dependencies.
-void run({List<String> ignoredPackages = const []}) {
+void run({
+  List<String> ignoredPackages = const [],
+  bool fatalUnderPromoted = true,
+  bool fatalOverPromoted = true,
+  bool fatalMissing = true,
+  bool fatalDevMissing = true,
+  bool fatalUnused = true,
+}) {
   // Read and parse the pubspec.yaml in the current working directory.
   final YamlMap pubspecYaml = loadYaml(new File('pubspec.yaml').readAsStringSync());
 
@@ -107,7 +114,7 @@ void run({List<String> ignoredPackages = const []}) {
       'These packages are used in lib/ but are not dependencies:',
       missingDependencies,
     );
-    exitCode = 1;
+    if (fatalMissing) exitCode = 1;
   }
 
   // Packages that are used outside lib/ but are not dev_dependencies.
@@ -128,7 +135,7 @@ void run({List<String> ignoredPackages = const []}) {
       'These packages are used outside lib/ but are not dev_dependencies:',
       missingDevDependencies,
     );
-    exitCode = 1;
+    if (fatalDevMissing) exitCode = 1;
   }
 
   // Packages that are not used in lib/, but are used elsewhere, that are
@@ -145,7 +152,7 @@ void run({List<String> ignoredPackages = const []}) {
       'These packages are only used outside lib/ and should be downgraded to dev_dependencies:',
       overPromotedDependencies,
     );
-    exitCode = 1;
+    if (fatalOverPromoted) exitCode = 1;
   }
 
   // Packages that are used in lib/, but are dev_dependencies.
@@ -160,7 +167,7 @@ void run({List<String> ignoredPackages = const []}) {
       'These packages are used in lib/ and should be promoted to actual dependencies:',
       underPromotedDependencies,
     );
-    exitCode = 1;
+    if (fatalUnderPromoted) exitCode = 1;
   }
 
   // Packages that are not used anywhere but are dependencies.
@@ -193,10 +200,10 @@ void run({List<String> ignoredPackages = const []}) {
       unusedDependencies,
     );
 
-    exitCode = 1;
+    if (fatalUnused) exitCode = 1;
   }
 
   if (exitCode == 0) {
-    logger.info('No infractions found, $packageName is good to go!');
+    logger.info('No fatal infractions found, $packageName is good to go!');
   }
 }


### PR DESCRIPTION
## Ultimate Problem
We need the ability to not fail when there are missing developer dependencies. Because these don't affect the dependency tree for consumers it's not a big deal.

## Solution
- Add flags for turning off failing for each validation check.
  - Note: I only see the `--no-fatal-missing-dev` flag being used.

## Testing Suggestions
- Verify tests pass

## Possible Areas of Regression
Properly failing when it is expected to fail.

---
FYA: @greglittlefield-wf @toddbeckman-wf @maxwellpeterson-wf 
FYI: @evanweible-wf 