### PR TITLE
UIP-3068 Add ability to exclude directories when checking for infractions

### DIFF
--- a/bin/dependency_validator.dart
+++ b/bin/dependency_validator.dart
@@ -21,6 +21,7 @@ import 'package:dependency_validator/dependency_validator.dart';
 final ArgParser argParser = new ArgParser()
   ..addFlag('verbose', defaultsTo: false)
   ..addOption('ignore', abbr: 'i', allowMultiple: true, splitCommas: true)
+  ..addOption('exclude-dir', abbr: 'x', allowMultiple: true, splitCommas: true)
   ..addFlag('fatal-under-promoted', defaultsTo: true)
   ..addFlag('fatal-over-promoted', defaultsTo: true)
   ..addFlag('fatal-missing', defaultsTo: true)
@@ -48,6 +49,14 @@ void main(List<String> args) {
     ignoredPackages = const <String>[];
   }
 
+  List<String> excludedDirs;
+
+  if (argResults.wasParsed('exclude-dir')) {
+    excludedDirs = argResults['exclude-dir'];
+  } else {
+    excludedDirs = const <String>[];
+  }
+
   Logger.root.onRecord
       .where((record) => record.level < Level.WARNING)
       .map((record) => record.message)
@@ -59,6 +68,7 @@ void main(List<String> args) {
 
   run(
     ignoredPackages: ignoredPackages,
+    excludedDirs: excludedDirs,
     fatalUnderPromoted: fatalUnderPromoted,
     fatalOverPromoted: fatalOverPromoted,
     fatalMissing: fatalMissing,

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -21,6 +21,7 @@ import './src/utils.dart';
 /// Check for missing, under-promoted, over-promoted, and unused dependencies.
 void run({
   List<String> ignoredPackages = const [],
+  List<String> excludedDirs = const [],
   bool fatalUnderPromoted = true,
   bool fatalOverPromoted = true,
   bool fatalMissing = true,
@@ -60,7 +61,7 @@ void run({
       '${bulletItems(packagesUsedViaTransformers)}\n');
 
   // Recursively list all Dart files in lib/
-  final publicDartFiles = <File>[]..addAll(listDartFilesIn('lib/'))..addAll(listDartFilesIn('bin/'));
+  final publicDartFiles = <File>[]..addAll(listDartFilesIn('lib/', excludedDirs))..addAll(listDartFilesIn('bin/', excludedDirs));
   logger.fine('public facing dart files:\n'
       '${bulletItems(publicDartFiles.map((f) => f.path))}\n');
 
@@ -78,10 +79,10 @@ void run({
 
   // Recursively list all Dart files in known directories other than lib/
   final nonLibDartFiles = <File>[]
-    ..addAll(listDartFilesIn('example/'))
-    ..addAll(listDartFilesIn('test/'))
-    ..addAll(listDartFilesIn('tool/'))
-    ..addAll(listDartFilesIn('web/'));
+    ..addAll(listDartFilesIn('example/', excludedDirs))
+    ..addAll(listDartFilesIn('test/', excludedDirs))
+    ..addAll(listDartFilesIn('tool/', excludedDirs))
+    ..addAll(listDartFilesIn('web/', excludedDirs));
   logger.fine('non-lib dart files:\n'
       '${bulletItems(nonLibDartFiles.map((f) => f.path))}\n');
 

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -61,7 +61,9 @@ void run({
       '${bulletItems(packagesUsedViaTransformers)}\n');
 
   // Recursively list all Dart files in lib/
-  final publicDartFiles = <File>[]..addAll(listDartFilesIn('lib/', excludedDirs))..addAll(listDartFilesIn('bin/', excludedDirs));
+  final publicDartFiles = <File>[]
+    ..addAll(listDartFilesIn('lib/', excludedDirs))
+    ..addAll(listDartFilesIn('bin/', excludedDirs));
   logger.fine('public facing dart files:\n'
       '${bulletItems(publicDartFiles.map((f) => f.path))}\n');
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -31,18 +31,15 @@ String bulletItems(Iterable<String> items) => items.map((l) => '  * $l').join('\
 
 Iterable<File> listDartFilesIn(String dirPath, List<String> excludedDirs) {
   if (!FileSystemEntity.isDirectorySync(dirPath)) return const [];
-  final files = new Directory(dirPath)
-      .listSync(recursive: true)
-      .where((entity) {
-        if (entity is! File) return false;
-        if (entity.path.contains('/packages/')) return false;
-        if (!entity.path.endsWith('.dart')) return false;
-        if (excludedDirs.any(entity.path.startsWith)) return false;
 
-        return true;
-      });
+  return new Directory(dirPath).listSync(recursive: true).where((entity) {
+    if (entity is! File) return false;
+    if (entity.path.contains('/packages/')) return false;
+    if (!entity.path.endsWith('.dart')) return false;
+    if (excludedDirs.any(entity.path.startsWith)) return false;
 
-  return files;
+    return true;
+  });
 }
 
 void logDependencyInfractions(String infraction, Iterable<String> dependencies) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -15,6 +15,7 @@
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 
 final RegExp importExportPackageRegex =
     new RegExp(r'''^(import|export)\s+['"]package:([a-zA-Z_]+)\/.+$''', multiLine: true);
@@ -34,9 +35,9 @@ Iterable<File> listDartFilesIn(String dirPath, List<String> excludedDirs) {
 
   return new Directory(dirPath).listSync(recursive: true).where((entity) {
     if (entity is! File) return false;
-    if (entity.path.contains('/packages/')) return false;
-    if (!entity.path.endsWith('.dart')) return false;
-    if (excludedDirs.any(entity.path.startsWith)) return false;
+    if (entity.path.split(p.separator).contains('packages')) return false;
+    if (p.extension(entity.path) != ('.dart')) return false;
+    if (excludedDirs.any((dir) => p.isWithin(dir, entity.path))) return false;
 
     return true;
   });

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -29,11 +29,20 @@ final Logger logger = new Logger('dependency_validator');
 
 String bulletItems(Iterable<String> items) => items.map((l) => '  * $l').join('\n');
 
-Iterable<File> listDartFilesIn(String dirPath) {
+Iterable<File> listDartFilesIn(String dirPath, List<String> excludedDirs) {
   if (!FileSystemEntity.isDirectorySync(dirPath)) return const [];
-  return new Directory(dirPath)
+  final files = new Directory(dirPath)
       .listSync(recursive: true)
-      .where((entity) => entity is File && !entity.path.contains('/packages/') && entity.path.endsWith('.dart'));
+      .where((entity) {
+        if (entity is! File) return false;
+        if (entity.path.contains('/packages/')) return false;
+        if (!entity.path.endsWith('.dart')) return false;
+        if (excludedDirs.any(entity.path.startsWith)) return false;
+
+        return true;
+      });
+
+  return files;
 }
 
 void logDependencyInfractions(String infraction, Iterable<String> dependencies) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -35,7 +35,7 @@ Iterable<File> listDartFilesIn(String dirPath, List<String> excludedDirs) {
 
   return new Directory(dirPath).listSync(recursive: true).where((entity) {
     if (entity is! File) return false;
-    if (entity.path.split(p.separator).contains('packages')) return false;
+    if (p.split(entity.path).contains('packages')) return false;
     if (p.extension(entity.path) != ('.dart')) return false;
     if (excludedDirs.any((dir) => p.isWithin(dir, entity.path))) return false;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   args: ^0.13.7
   logging: ^0.11.3+1
+  path: ^1.4.2
   yaml: ^2.1.13
 
 dev_dependencies:

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -28,6 +28,7 @@ const String projectWithNoProblems = 'test_fixtures/valid';
 ProcessResult checkProject(
   String projectPath, {
   List<String> ignoredPackages = const [],
+  List<String> excludeDirs = const [],
   bool fatalUnderPromoted = true,
   bool fatalOverPromoted = true,
   bool fatalMissing = true,
@@ -39,6 +40,7 @@ ProcessResult checkProject(
   final args = ['run', 'dependency_validator'];
 
   if (ignoredPackages.isNotEmpty) args..add('--ignore')..add(ignoredPackages.join(','));
+  if (excludeDirs.isNotEmpty) args..add('--exclude-dir')..add(excludeDirs.join(','));
   if (!fatalDevMissing) args.add('--no-fatal-dev-mising');
   if (!fatalMissing) args.add('--no-fatal-missing');
   if (!fatalOverPromoted) args.add('--no-fatal-over-promoted');
@@ -65,6 +67,13 @@ void main() {
         expect(result.exitCode, equals(0));
         expect(result.stderr, contains('These packages are used in lib/ but are not dependencies:'));
         expect(result.stderr, contains('yaml'));
+      });
+
+      test('expect when the lib directory is excluded', () {
+        final result = checkProject(projectWithMissingDeps, excludeDirs: ['lib/']);
+
+        expect(result.exitCode, equals(0));
+        expect(result.stderr, isEmpty);
       });
     });
 

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -61,7 +61,7 @@ void main() {
         expect(result.stderr, contains('yaml'));
       });
 
-      test('expect when the --no-fatal-missing flag is passed in', () {
+      test('except when the --no-fatal-missing flag is passed in', () {
         final result = checkProject(projectWithMissingDeps, fatalMissing: false);
 
         expect(result.exitCode, equals(0));
@@ -69,7 +69,7 @@ void main() {
         expect(result.stderr, contains('yaml'));
       });
 
-      test('expect when the lib directory is excluded', () {
+      test('except when the lib directory is excluded', () {
         final result = checkProject(projectWithMissingDeps, excludeDirs: ['lib/']);
 
         expect(result.exitCode, equals(0));


### PR DESCRIPTION
## Ultimate Problem
https://github.com/Workiva/dependency_validator/issues/8

## Solution
- Add the `--exclude-dir` flag

## Testing Suggestions
- Verify tests pass

## Possible Areas of Regression
- Error reporting

---
FYA: @greglittlefield-wf @maxwellpeterson-wf @toddbeckman-wf 
FYI: @evanweible-wf 