### PR TITLE
UIP-3088 Fix detection of packages whose names contain numbers

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -18,7 +18,7 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
 final RegExp importExportPackageRegex =
-    new RegExp(r'''^(import|export)\s+['"]package:([a-zA-Z0-9_]+)\/.+$''', multiLine: true);
+    new RegExp(r'''^\s*(import|export)\s+['"]{1,3}package:([a-zA-Z0-9_]+)\/.+$''', multiLine: true);
 
 const dependenciesKey = 'dependencies';
 const dependencyValidatorPackageName = 'dependency_validator';

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -18,7 +18,7 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
 final RegExp importExportPackageRegex =
-    new RegExp(r'''^\s*(import|export)\s+['"]{1,3}package:([a-zA-Z0-9_]+)\/.+$''', multiLine: true);
+    new RegExp(r'''\b(import|export)\s+['"]{1,3}package:([a-zA-Z0-9_]+)\/[^;]+''', multiLine: true);
 
 const dependenciesKey = 'dependencies';
 const dependencyValidatorPackageName = 'dependency_validator';

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -18,7 +18,7 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
 final RegExp importExportPackageRegex =
-    new RegExp(r'''^(import|export)\s+['"]package:([a-zA-Z_]+)\/.+$''', multiLine: true);
+    new RegExp(r'''^(import|export)\s+['"]package:([a-zA-Z0-9_]+)\/.+$''', multiLine: true);
 
 const dependenciesKey = 'dependencies';
 const dependencyValidatorPackageName = 'dependency_validator';

--- a/test/import_export_regex_test.dart
+++ b/test/import_export_regex_test.dart
@@ -60,6 +60,18 @@ main() {
         test('with extra whitespace in the line', () {
           sharedTest('   $importOrExport   "package:foo/bar.dart"   ;   ', importOrExport, 'foo');
         });
+
+        test('with multiple ${importOrExport}s in the same line', () {
+          final input = '$importOrExport "package:foo/bar.dart"; $importOrExport "package:bar/foo.dart";';
+
+          expect(input, matches(importExportPackageRegex));
+
+          final allMatches = importExportPackageRegex.allMatches(input).toList();
+          expect(allMatches, hasLength(2));
+
+          expect(allMatches[0].groups([1, 2]), [importOrExport, 'foo']);
+          expect(allMatches[1].groups([1, 2]), [importOrExport, 'bar']);
+        });
       });
     }
   });

--- a/test/import_export_regex_test.dart
+++ b/test/import_export_regex_test.dart
@@ -43,16 +43,18 @@ main() {
           sharedTest('$importOrExport \'\'\'package:foo/bar.dart\'\'\';', importOrExport, 'foo');
         });
 
-        test('with underscores in the package name', () {
-          sharedTest('$importOrExport "package:foo_foo/bar.dart";', importOrExport, 'foo_foo');
-        });
+        group('with a package name that', () {
+          test('contains underscores', () {
+            sharedTest('$importOrExport "package:foo_foo/bar.dart";', importOrExport, 'foo_foo');
+          });
 
-        test('with numbers in the package name', () {
-          sharedTest('$importOrExport "package:foo1/bar.dart";', importOrExport, 'foo1');
-        });
+          test('contains numbers', () {
+            sharedTest('$importOrExport "package:foo1/bar.dart";', importOrExport, 'foo1');
+          });
 
-        test('that starts with an underscore', () {
-          sharedTest('$importOrExport "package:_foo/bar.dart";', importOrExport, '_foo');
+          test('starts with an underscore', () {
+            sharedTest('$importOrExport "package:_foo/bar.dart";', importOrExport, '_foo');
+          });
         });
 
         test('with extra whitespace in the line', () {

--- a/test/import_export_regex_test.dart
+++ b/test/import_export_regex_test.dart
@@ -35,6 +35,14 @@ main() {
           sharedTest('$importOrExport \'package:foo/bar.dart\';', importOrExport, 'foo');
         });
 
+        test('with triple double-quotes', () {
+          sharedTest('$importOrExport """package:foo/bar.dart""";', importOrExport, 'foo');
+        });
+
+        test('with triple single-quotes', () {
+          sharedTest('$importOrExport \'\'\'package:foo/bar.dart\'\'\';', importOrExport, 'foo');
+        });
+
         test('with underscores in the package name', () {
           sharedTest('$importOrExport "package:foo_foo/bar.dart";', importOrExport, 'foo_foo');
         });
@@ -45,6 +53,10 @@ main() {
 
         test('that starts with an underscore', () {
           sharedTest('$importOrExport "package:_foo/bar.dart";', importOrExport, '_foo');
+        });
+
+        test('with extra whitespace in the line', () {
+          sharedTest('   $importOrExport   "package:foo/bar.dart"   ;   ', importOrExport, 'foo');
         });
       });
     }

--- a/test/import_export_regex_test.dart
+++ b/test/import_export_regex_test.dart
@@ -1,0 +1,52 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+
+import 'package:test/test.dart';
+
+import 'package:dependency_validator/src/utils.dart';
+
+main() {
+  group('importExportPackageRegex matches correctly for', () {
+    void sharedTest(String input, String expectedGroup1, String expectedGroup2) {
+      expect(input, matches(importExportPackageRegex));
+      expect(importExportPackageRegex.firstMatch(input).groups([1, 2]), [expectedGroup1, expectedGroup2]);
+    }
+
+    for (var importOrExport in ['import', 'export']) {
+      group('an $importOrExport line', () {
+        test('with double-quotes', () {
+          sharedTest('$importOrExport "package:foo/bar.dart";', importOrExport, 'foo');
+        });
+
+        test('with single-quotes', () {
+          sharedTest('$importOrExport \'package:foo/bar.dart\';', importOrExport, 'foo');
+        });
+
+        test('with underscores in the package name', () {
+          sharedTest('$importOrExport "package:foo_foo/bar.dart";', importOrExport, 'foo_foo');
+        });
+
+        test('with numbers in the package name', () {
+          sharedTest('$importOrExport "package:foo1/bar.dart";', importOrExport, 'foo1');
+        });
+
+        test('that starts with an underscore', () {
+          sharedTest('$importOrExport "package:_foo/bar.dart";', importOrExport, '_foo');
+        });
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Ultimate Problem
The regex that detected import/export statements didn't account for packages with numbers in their names.

This can cause false positives and false negatives when using dependnency_validator (I hit one of each when using it).

## Solution
- Account for numbers in package names
- Add tests for package name regex, including regression tests for package names with numbers
- Boyscouting: update regex for two additional edge cases:
    - Leading spaces
    - Triple-quoted exports (apparently you can do that)
    - imports/exports not separated by newlines
        - This is definitely an edge case, so let me know if my changes to the regex to support this too severe
    - Note: it looks like adjacent string concatenation is also allowed; supporting that is probably best left for another time (if at all), and best for a tool like `analyzer` as opposed to regex.

## Testing
Verify tests pass

## Areas of Regression
Detection of packages.