### PR TITLE
AF-137 add help option

### DIFF
--- a/bin/dependency_validator.dart
+++ b/bin/dependency_validator.dart
@@ -97,6 +97,11 @@ final ArgParser argParser = new ArgParser()
         '- web/\n',
   );
 
+void showHelpAndExit() {
+  Logger.root.shout(argParser.usage);
+  exit(0);
+}
+
 void main(List<String> args) {
   Logger.root.onRecord
       .where((record) => record.level < Level.WARNING)
@@ -107,11 +112,15 @@ void main(List<String> args) {
       .map((record) => record.message)
       .listen(stderr.writeln);
 
-  final argResults = argParser.parse(args);
+  ArgResults argResults;
+  try {
+    argResults = argParser.parse(args);
+  } catch (e) {
+    showHelpAndExit();
+  }
 
   if (argResults.wasParsed(helpArg) && argResults[helpArg]) {
-    Logger.root.shout(argParser.usage);
-    exit(0);
+    showHelpAndExit();
   }
 
   if (argResults.wasParsed(verboseArg) && argResults[verboseArg]) {

--- a/bin/dependency_validator.dart
+++ b/bin/dependency_validator.dart
@@ -12,36 +12,118 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:io' show stderr, stdout;
+import 'dart:io' show exit, stderr, stdout;
 
 import 'package:args/args.dart';
 import 'package:logging/logging.dart';
 import 'package:dependency_validator/dependency_validator.dart';
 
+const String helpArg = 'help';
+const String verboseArg = 'verbose';
+const String ignoreArg = 'ignore';
+
+const String excludeDirArg = 'exclude-dir';
+
+const String fatalPinsArg = 'fatal-pins';
+
+const String fatalMissingArg = 'fatal-missing';
+const String fatalDevMissingArg = 'fatal-dev-missing';
+
+const String fatalUnderPromotedArg = 'fatal-under-promoted';
+const String fatalOverPromotedArg = 'fatal-over-promoted';
+
+const String fatalUnusedArg = 'fatal-unused';
+
+/// Parses the command-line arguments
 final ArgParser argParser = new ArgParser()
-  ..addFlag('verbose', defaultsTo: false)
-  ..addOption('ignore', abbr: 'i', allowMultiple: true, splitCommas: true)
-  ..addOption('exclude-dir', abbr: 'x', allowMultiple: true, splitCommas: true)
-  ..addFlag('fatal-pins', defaultsTo: true)
-  ..addFlag('fatal-under-promoted', defaultsTo: true)
-  ..addFlag('fatal-over-promoted', defaultsTo: true)
-  ..addFlag('fatal-missing', defaultsTo: true)
-  ..addFlag('fatal-dev-missing', defaultsTo: true)
-  ..addFlag('fatal-unused', defaultsTo: true);
+  ..addFlag(
+    helpArg,
+    abbr: 'h',
+    help: 'Displays this info.',
+  )
+  ..addFlag(
+    verboseArg,
+    defaultsTo: false,
+    help: 'Display extra information for debugging.',
+  )
+  ..addOption(
+    ignoreArg,
+    abbr: 'i',
+    allowMultiple: true,
+    help: 'Comma-delimited list of packages to ignore from validation.',
+    splitCommas: true,
+  )
+  ..addOption(
+    excludeDirArg,
+    abbr: 'x',
+    allowMultiple: true,
+    help: 'Comma-delimited list of directories to exclude from validation.',
+    splitCommas: true,
+  )
+  ..addFlag(
+    fatalPinsArg,
+    defaultsTo: true,
+    help: 'Whether to fail on dependency pins.',
+  )
+  ..addFlag(
+    fatalUnderPromotedArg,
+    help: 'Whether to fail on dependencies that are in `dev_dependencies` that should be in `dependencies`.',
+    defaultsTo: true,
+  )
+  ..addFlag(
+    fatalOverPromotedArg,
+    defaultsTo: true,
+    help: 'Whether to fail on dependencies that are in `dependencies` that should be in `dev_dependencies`.',
+  )
+  ..addFlag(
+    fatalMissingArg,
+    defaultsTo: true,
+    help: 'Whether to fail on dependencies that are missing from `dependencies`.',
+  )
+  ..addFlag(
+    fatalDevMissingArg,
+    defaultsTo: true,
+    help: 'Whether to fail on dependencies that are missing from `dev_dependencies`.',
+  )
+  ..addFlag(
+    fatalUnusedArg,
+    defaultsTo: true,
+    help: 'Whether to fail on dependencies in the `pubspec.yaml` that are never used in any of:\n'
+        '- bin/\n'
+        '- lib/\n'
+        '- examples/\n'
+        '- test/\n'
+        '- tool/\n'
+        '- web/\n',
+  );
 
 void main(List<String> args) {
+  Logger.root.onRecord
+      .where((record) => record.level < Level.WARNING)
+      .map((record) => record.message)
+      .listen(stdout.writeln);
+  Logger.root.onRecord
+      .where((record) => record.level >= Level.WARNING)
+      .map((record) => record.message)
+      .listen(stderr.writeln);
+
   final argResults = argParser.parse(args);
 
-  if (argResults.wasParsed('verbose') && argResults['verbose']) {
+  if (argResults.wasParsed(helpArg) && argResults[helpArg]) {
+    Logger.root.shout(argParser.usage);
+    exit(0);
+  }
+
+  if (argResults.wasParsed(verboseArg) && argResults[verboseArg]) {
     Logger.root.level = Level.ALL;
   }
 
-  final fatalUnderPromoted = argResults['fatal-under-promoted'] ?? true;
-  final fatalOverPromoted = argResults['fatal-over-promoted'] ?? true;
-  final fatalMissing = argResults['fatal-missing'] ?? true;
-  final fatalDevMissing = argResults['fatal-dev-missing'] ?? true;
-  final fatalUnused = argResults['fatal-unused'] ?? true;
-  final fatalPins = argResults['fatal-pins'] ?? true;
+  final fatalUnderPromoted = argResults[fatalUnderPromotedArg] ?? true;
+  final fatalOverPromoted = argResults[fatalOverPromotedArg] ?? true;
+  final fatalMissing = argResults[fatalMissingArg] ?? true;
+  final fatalDevMissing = argResults[fatalDevMissingArg] ?? true;
+  final fatalUnused = argResults[fatalUnusedArg] ?? true;
+  final fatalPins = argResults[fatalPinsArg] ?? true;
 
   List<String> ignoredPackages;
 
@@ -58,15 +140,6 @@ void main(List<String> args) {
   } else {
     excludedDirs = const <String>[];
   }
-
-  Logger.root.onRecord
-      .where((record) => record.level < Level.WARNING)
-      .map((record) => record.message)
-      .listen(stdout.writeln);
-  Logger.root.onRecord
-      .where((record) => record.level >= Level.WARNING)
-      .map((record) => record.message)
-      .listen(stderr.writeln);
 
   run(
     excludedDirs: excludedDirs,


### PR DESCRIPTION
# Problem

This executable has no usage documentation.

# Solution

Add it.

```
? pub run dependency_validator -h 
-h, --[no-]help                    Displays this info.
    --[no-]verbose                 Display extra information for debugging.
-i, --ignore                       Comma-delimited list of packages to ignore from validation.
-x, --exclude-dir                  Comma-delimited list of directories to exclude from validation.
    --[no-]fatal-pins              Whether to fail on dependency pins.
                                   (defaults to on)

    --[no-]fatal-under-promoted    Whether to fail on dependencies that are in `dev_dependencies` that should be in `dependencies`.
                                   (defaults to on)

    --[no-]fatal-over-promoted     Whether to fail on dependencies that are in `dependencies` that should be in `dev_dependencies`.
                                   (defaults to on)

    --[no-]fatal-missing           Whether to fail on dependencies that are missing from `dependencies`.
                                   (defaults to on)

    --[no-]fatal-dev-missing       Whether to fail on dependencies that are missing from `dev_dependencies`.
                                   (defaults to on)

    --[no-]fatal-unused            Whether to fail on dependencies in the `pubspec.yaml` that are never used in any of:
                                   - bin/
                                   - lib/
                                   - examples/
                                   - test/
                                   - tool/
                                   - web/
                                   (defaults to on)
```

# Testing

- [ ] `pub run dependency_validator -h`
- [ ] `pub run dependency_validator --help`