### PR TITLE
Fix for DartSDK 2.0.0-dev.65.0+: Unhandled exception: type 'WhereIterable<FileSystemEntity>' is not a subtype of type 'Iterable<File>'

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -54,8 +54,8 @@ Iterable<File> listFilesWithExtensionIn(String dirPath, List<String> excludedDir
     if (excludedDirs.any((dir) => p.isWithin(dir, entity.path))) return false;
 
     return true;
-  // support for both Dart1 and Dart2
-  // ignore: cast_to_non_type
+    // support for both Dart1 and Dart2
+    // ignore: cast_to_non_type
   }).map((e) => e as File);
 }
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -54,7 +54,9 @@ Iterable<File> listFilesWithExtensionIn(String dirPath, List<String> excludedDir
     if (excludedDirs.any((dir) => p.isWithin(dir, entity.path))) return false;
 
     return true;
-  }).cast<File>();
+  // support for both Dart1 and Dart2
+  // ignore: cast_to_non_type
+  }).map((e) => e as File);
 }
 
 /// Logs a warning with the given [infraction] and lists all of the given

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -54,7 +54,7 @@ Iterable<File> listFilesWithExtensionIn(String dirPath, List<String> excludedDir
     if (excludedDirs.any((dir) => p.isWithin(dir, entity.path))) return false;
 
     return true;
-  });
+  }).cast<File>();
 }
 
 /// Logs a warning with the given [infraction] and lists all of the given

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   coverage: '>=0.9.3 <0.11.0'
   dartdoc: '>=0.14.1 <0.19.0'
-  dart_dev: ^1.8.0
+  dart_dev: ^2.0.0-alpha
   dart_style: ^1.0.8
   test: ^0.12.24+8
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
 
 environment:
-  sdk: ">=2.0.0-dev.65.0 <3.0.0"
+  sdk: ">=1.24.2 <3.0.0"
 
 dependencies:
   args: '>=0.13.7 <2.0.0'
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   coverage: '>=0.9.3 <0.11.0'
   dartdoc: '>=0.14.1 <0.19.0'
-  dart_dev: ^2.0.0-alpha
+  dart_dev: ^1.8.0
   dart_style: ^1.0.8
   test: ^0.12.24+8
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
 
 environment:
-  sdk: ">=1.24.2 <2.0.0"
+  sdk: ">=2.0.0-dev.65.0 <3.0.0"
 
 dependencies:
   args: '>=0.13.7 <2.0.0'


### PR DESCRIPTION
Since DartSDK 2.0.0-dev.65.0, VM flag --preview-dart-2 is enabled by default and can't be disabled.
That causes runtime error, like
```
Unhandled exception:
type 'WhereIterable<FileSystemEntity>' is not a subtype of type 'Iterable<File>'
#0      listFilesWithExtensionIn (package:dependency_validator/src/utils.dart:50:59)
#1      listDartFilesIn (package:dependency_validator/src/utils.dart:34:5)
#2      run (package:dependency_validator/dependency_validator.dart:69:14)
#3      main (file:///Users/yury.yufimov/work/tmp/dependency_validator/bin/dependency_validator.dart:153:3)
#4      _startIsolate.<anonymous closure> (dart:isolate/runtime/libisolate_patch.dart:277:32)
#5      _RawReceivePortImpl._handleMessage (dart:isolate/runtime/libisolate_patch.dart:165:12)
```


