### PR TITLE
AF-1887 Release dependency_validator 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.2
+
+- **Bug Fix:** Ignoring a package via `--ignore` or `-i` will now also
+  work as expected for the "pinned dependency" failure. [#39][#39]
+
+[#39]: https://github.com/Workiva/dependency_validator/pull/39
+
 # 1.2.1
 
 - Dart 2 compatible. [#35][#35]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 1.2.1
+version: 1.2.2
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [pins not ignoring packages](https://github.com/Workiva/dependency_validator/pull/37)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dependency_validator/compare/1.2.1...Workiva:release_dependency_validator_1_2_2
Diff Between Last Tag and New Tag: https://github.com/Workiva/dependency_validator/compare/1.2.1...1.2.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5160374167404544/logs/)