### PR TITLE
AF-2011 should not throw when no max bound

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -117,6 +117,10 @@ DependencyPinEvaluation inspectVersionForPins(String version) {
 
     final Version max = constraint.max;
 
+    if (max == null) {
+      return DependencyPinEvaluation.notAPin;
+    }
+
     if (max.build.isNotEmpty || (max.isPreRelease && !max.isFirstPreRelease)) {
       return DependencyPinEvaluation.buildOrPrerelease;
     }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -218,6 +218,10 @@ void main() {
         expect(inspectVersionForPins('>=0.2.0 <0.3.0'), DependencyPinEvaluation.notAPin);
         expect(inspectVersionForPins('<0.2.0'), DependencyPinEvaluation.notAPin);
       });
+
+      test('unset', () {
+        expect(inspectVersionForPins('>=0.2.0'), DependencyPinEvaluation.notAPin);
+      });
     });
   });
 }


### PR DESCRIPTION
When there is a min but not a max, dep validator fails:

https://ci.webfilings.com/build/1392171


# Testing

Run this on that library with these changes.