### PR TITLE
AF-3771 Fix bug with ignoring over-promoted deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.4
+
+- **Bug Fix:** Ignoring a package via `--ignore` or `-i` will now also work as
+  expected for the "over-promoted" failure. [#44][#44]
+
+[#44]: https://github.com/Workiva/dependency_validator/pull/44
+
 # 1.2.2
 
 - **Bug Fix:** Ignoring a package via `--ignore` or `-i` will now also

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -180,10 +180,12 @@ void run({
   // dependencies when they should be dev_dependencies.
   final overPromotedDependencies =
       // Start with dependencies that are not used in lib/
-      deps
+      (deps
           .difference(packagesUsedInPublicFiles)
           // Intersect with deps that are used outside lib/ (excludes unused deps)
-          .intersection(packagesUsedOutsideLib);
+          .intersection(packagesUsedOutsideLib))
+        // Ignore known over-promoted packages.
+        ..removeAll(ignoredPackages);
 
   if (overPromotedDependencies.isNotEmpty) {
     logDependencyInfractions(

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -83,6 +83,11 @@ void main() {
         expect(result.exitCode, equals(0));
         expect(result.stderr, isEmpty);
       });
+
+      test('except when they are ignored', () {
+        final result = checkProject(projectWithMissingDeps, ignoredPackages: ['yaml', 'somescsspackage']);
+        expect(result.exitCode, 0);
+      });
     });
 
     group('fails when there are over promoted packages', () {
@@ -104,6 +109,11 @@ void main() {
             contains('These packages are only used outside lib/ and should be downgraded to dev_dependencies:'));
         expect(result.stderr, contains('path'));
         expect(result.stderr, contains('yaml'));
+      });
+
+      test('except when they are ignored', () {
+        final result = checkProject(projectWithOverPromotedDeps, ignoredPackages: ['path', 'yaml']);
+        expect(result.exitCode, 0);
       });
     });
 
@@ -127,6 +137,11 @@ void main() {
         expect(result.stderr, contains('logging'));
         expect(result.stderr, contains('yaml'));
       });
+
+      test('except when they are ignored', () {
+        final result = checkProject(projectWithUnderPromotedDeps, ignoredPackages: ['logging', 'yaml']);
+        expect(result.exitCode, 0);
+      });
     });
 
     group('fails when there are unused packages', () {
@@ -146,6 +161,11 @@ void main() {
         expect(result.stderr,
             contains('These packages may be unused, or you may be using executables or assets from these packages:'));
         expect(result.stderr, contains('fake_project'));
+      });
+
+      test('except when they are ignored', () {
+        final result = checkProject(projectWithUnusedDeps, ignoredPackages: ['fake_project']);
+        expect(result.exitCode, 0);
       });
     });
 

--- a/test_fixtures/analyzer/pubspec.lock
+++ b/test_fixtures/analyzer/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.32.4"
+    version: "0.33.3+1"
   args:
     dependency: transitive
     description:
@@ -56,21 +56,21 @@ packages:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.4+1"
+    version: "0.14.6"
   dependency_validator:
     dependency: "direct dev"
     description:
       path: "../.."
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   front_end:
     dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.6+4"
   glob:
     dependency: transitive
     description:
@@ -84,14 +84,14 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3+2"
+    version: "0.13.3+3"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.6+4"
   logging:
     dependency: transitive
     description:

--- a/test_fixtures/dependency_pins/pubspec.lock
+++ b/test_fixtures/dependency_pins/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2"
+    version: "0.12.3"
   crypto:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   json_rpc_2:
     dependency: transitive
     description:

--- a/test_fixtures/missing/pubspec.lock
+++ b/test_fixtures/missing/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   logging:
     dependency: transitive
     description:

--- a/test_fixtures/over_promoted/pubspec.lock
+++ b/test_fixtures/over_promoted/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   logging:
     dependency: transitive
     description:

--- a/test_fixtures/under_promoted/pubspec.lock
+++ b/test_fixtures/under_promoted/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   logging:
     dependency: "direct dev"
     description:

--- a/test_fixtures/unused/pubspec.lock
+++ b/test_fixtures/unused/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   fake_project:
     dependency: "direct dev"
     description:

--- a/test_fixtures/valid/pubspec.lock
+++ b/test_fixtures/valid/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.32.4"
+    version: "0.33.3+1"
   args:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.4+1"
+    version: "0.14.6"
   dependency_validator:
     dependency: "direct dev"
     description:
       path: "../.."
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   fake_project:
     dependency: "direct main"
     description:
@@ -84,7 +84,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.6+4"
   glob:
     dependency: transitive
     description:
@@ -98,14 +98,14 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3+2"
+    version: "0.13.3+3"
   http:
     dependency: transitive
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+17"
+    version: "0.12.0+1"
   http_multi_server:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.6+4"
   logging:
     dependency: "direct main"
     description:
@@ -203,7 +203,7 @@ packages:
       name: package_resolver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.6"
   path:
     dependency: transitive
     description:
@@ -224,7 +224,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "1.4.0"
   pub_semver:
     dependency: transitive
     description:
@@ -238,7 +238,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3+3"
+    version: "0.7.4"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -259,7 +259,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2+3"
+    version: "0.2.2+4"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -273,7 +273,7 @@ packages:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.7"
+    version: "0.10.8"
   source_span:
     dependency: transitive
     description:
@@ -315,7 +315,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.1+1"
+  test_api:
+    dependency: transitive
+    description:
+      name: test_api
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0+1"
   typed_data:
     dependency: transitive
     description:
@@ -359,4 +373,4 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.0.0-dev.62.0 <3.0.0"
+  dart: ">=2.0.0 <3.0.0"


### PR DESCRIPTION
## Description
The `--ignore` should allow consumers to exempt a known over-promoted dependency, but was not.

## Testing
- [ ] CI passes (tests added)

## Code Review
@corwinsheahan-wf @sebastianmalysa-wf @robbecker-wf 
fyi @travissanderson-wf 