### PR TITLE
AF-2531 Release dependency_validator 1.2.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 1.2.3
+version: 1.2.4
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* [AF-2011 should not throw when no max bound](https://github.com/Workiva/dependency_validator/pull/40)
* [AF-3771 Fix bug with ignoring over-promoted deps](https://github.com/Workiva/dependency_validator/pull/44)


Requested by: @evan.weible

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dependency_validator/compare/1.2.3...Workiva:release_dependency_validator_1.2.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/dependency_validator/compare/1.2.3...1.2.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5160374167404544/logs/)