### PR TITLE
CPLAT-8095: Add `dart_dev` to commonBinaryPackages

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -29,6 +29,7 @@ const List<String> commonBinaryPackages = [
   'built_value_generator',
   'coverage',
   'dart_style',
+  'dart_dev',
 ];
 
 /// Provides a set of reasons why version strings might be pins.

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -28,8 +28,8 @@ const List<String> commonBinaryPackages = [
   'build_web_compilers',
   'built_value_generator',
   'coverage',
-  'dart_style',
   'dart_dev',
+  'dart_style',
 ];
 
 /// Provides a set of reasons why version strings might be pins.

--- a/test_fixtures/common_binaries/pubspec.yaml
+++ b/test_fixtures/common_binaries/pubspec.yaml
@@ -12,6 +12,7 @@ dev_dependencies:
   build_web_compilers: ">=0.2.0 <2.0.0"
   built_value_generator: ">=5.1.3 <7.0.0"
   coverage: any
+  dart_dev: ^3.0.0
   dart_style: ^1.0.9+1
   dependency_validator:
     path: ../..


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
When we use `workivaConfig` without customization `dart_dev` gets flagged by  `dependency_validator`.
## Changes
  <!-- What this PR changes to fix the problem. -->
`dart_dev` added to default ignore list
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
        - [ ] CI should be sufficient
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#manual-testing-criteria
