### PR TITLE
CPLAT-8601: Detect package use in analysis_options.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.4.2
+
+- Detect package usage in `analysis_options.yaml` files.
+
+# 1.4.1
+
+- Add `dart_dev` to common binaries list so that it is automatically ignored.
+
 # 1.4.0
 
 - **Improvement:** Add `coverage` and `build_vm_compilers` to the list of

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -32,6 +32,9 @@ void run({
   bool fatalUnused = true,
   List<String> ignoredPackages = const [],
 }) {
+  // Read and parse the analysis_options.yaml in the current working directory.
+  final optionsIncludePackage = getAnalysisOptionsIncludePackage();
+
   // Read and parse the pubspec.yaml in the current working directory.
   final YamlMap pubspecYaml = loadYaml(File('pubspec.yaml').readAsStringSync());
 
@@ -118,7 +121,9 @@ void run({
 
   // Read each file outside lib/ and parse the package names from every
   // import and export directive.
-  final packagesUsedOutsideLib = <String>{};
+  final packagesUsedOutsideLib = <String>{
+    if (optionsIncludePackage != null) optionsIncludePackage,
+  };
   for (final file in nonLibDartFiles) {
     final matches = importExportDartPackageRegex.allMatches(file.readAsStringSync());
     for (final match in matches) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -17,6 +17,7 @@ import 'dart:io';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
 
 import 'constants.dart';
 
@@ -25,6 +26,21 @@ final Logger logger = Logger('dependency_validator');
 
 /// Returns a multi-line string with all [items] in a bulleted list format.
 String bulletItems(Iterable<String> items) => items.map((l) => '  * $l').join('\n');
+
+/// Returns the name of the package referenced in the `include:` directive in an
+/// analysis_options.yaml file, or null if there is not one.
+String getAnalysisOptionsIncludePackage({String path}) {
+  final optionsFile = File(p.join(path ?? p.current, 'analysis_options.yaml'));
+  if (!optionsFile.existsSync()) return null;
+
+  final YamlMap analysisOptions = loadYaml(optionsFile.readAsStringSync());
+  if (analysisOptions == null) return null;
+
+  final String include = analysisOptions['include'];
+  if (include == null || !include.startsWith('package:')) return null;
+
+  return Uri.parse(include).pathSegments.first;
+}
 
 /// Returns an iterable of all Dart files (files ending in .dart) in the given
 /// [dirPath] excluding any sub-directories specified in [excludedDirs].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   args: '>=0.13.7 <2.0.0'
@@ -17,7 +17,8 @@ dependencies:
   yaml: ^2.1.13
 
 dev_dependencies:
-  test: '>=0.12.30 <2.0.0'
+  test: ^1.9.4
+  test_descriptor: ^1.2.0
 
 executables:
   dependency_validator:

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -42,20 +42,34 @@ ProcessResult checkProject(
 }) {
   Process.runSync('pub', ['get'], workingDirectory: projectPath);
 
-  final args = ['run', 'dependency_validator'];
-
-  if (ignoredPackages.isNotEmpty) args..add('--ignore')..add(ignoredPackages.join(','));
-  if (excludeDirs.isNotEmpty) args..add('--exclude-dir')..add(excludeDirs.join(','));
-  if (!fatalDevMissing) args.add('--no-fatal-dev-mising');
-  if (!fatalMissing) args.add('--no-fatal-missing');
-  if (!fatalOverPromoted) args.add('--no-fatal-over-promoted');
-  if (!fatalUnderPromoted) args.add('--no-fatal-under-promoted');
-  if (!fatalUnused) args.add('--no-fatal-unused');
-  if (!fatalPins) args.add('--no-fatal-pins');
-  if (!ignoreCommonBinaries) args.add('--no-ignore-common-binaries');
-
-  // This makes it easier to print(result.stdout) for debugging tests
-  args.add('--verbose');
+  final args = [
+    'run',
+    'dependency_validator',
+    if (ignoredPackages.isNotEmpty) ...[
+      '--ignore',
+      ignoredPackages.join(','),
+    ],
+    if (excludeDirs.isNotEmpty) ...[
+      '--exclude-dir',
+      excludeDirs.join(','),
+    ],
+    if (!fatalDevMissing)
+      '--no-fatal-dev-mising',
+    if (!fatalMissing)
+      '--no-fatal-missing',
+    if (!fatalOverPromoted)
+      '--no-fatal-over-promoted',
+    if (!fatalUnderPromoted)
+      '--no-fatal-under-promoted',
+    if (!fatalUnused)
+      '--no-fatal-unused',
+    if (!fatalPins)
+      '--no-fatal-pins',
+    if (!ignoreCommonBinaries)
+      '--no-ignore-common-binaries',
+    // This makes it easier to print(result.stdout) for debugging tests
+    '--verbose',
+  ];
 
   return Process.runSync('pub', args, workingDirectory: projectPath);
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -15,11 +15,38 @@
 @TestOn('vm')
 
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'package:dependency_validator/src/constants.dart';
 import 'package:dependency_validator/src/utils.dart';
 
 void main() {
+  group('getAnalysisOptionsIncludePackage', () {
+    test('no analysis_options.yaml', () {
+      expect(getAnalysisOptionsIncludePackage(path: d.sandbox), isNull);
+    });
+
+    test('empty file', () async {
+      await d.file('analysis_options.yaml', '').create();
+      expect(getAnalysisOptionsIncludePackage(path: d.sandbox), isNull);
+    });
+
+    test('no `include:`', () async {
+      await d.file('analysis_options.yaml', '''
+linter:
+  rules: []
+''').create();
+      expect(getAnalysisOptionsIncludePackage(path: d.sandbox), isNull);
+    });
+
+    test('returns package name from `include:`', () async {
+      await d.file('analysis_options.yaml', '''
+include: package:pedantic/analysis_options.1.8.0.yaml
+''').create();
+      expect(getAnalysisOptionsIncludePackage(path: d.sandbox), 'pedantic');
+    });
+  });
+
   group('importExportDartPackageRegex matches correctly for', () {
     void sharedTest(String input, String expectedGroup1, String expectedGroup2) {
       expect(input, matches(importExportDartPackageRegex));

--- a/test_fixtures/valid/analysis_options.yaml
+++ b/test_fixtures/valid/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.1.8.0.yaml

--- a/test_fixtures/valid/pubspec.yaml
+++ b/test_fixtures/valid/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
 dev_dependencies:
   dependency_validator:
     path: ../..
+  pedantic: any
   test: any
 
 transformers:


### PR DESCRIPTION
Packages can include analysis options from another package in their own `analysis_options.yaml`. This PR adds support for detecting that usage so that it doesn't think that a package only depended on for that purpose is unused.