### PR TITLE
Validate less imports

### DIFF
--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -59,10 +59,9 @@ void run({
   // Extract the package names from the `transformers` section.
   final Iterable transformerEntries = pubspecYaml[transformersKey];
   final packagesUsedViaTransformers = pubspecYaml.containsKey(transformersKey)
-      ? Set<String>.from(transformerEntries.map<String>((value) {
-          if (value is YamlMap) return value.keys.first;
-          return value;
-        }).map((value) => value.replaceFirst(RegExp(r'/.*'), '')))
+      ? Set<String>.from(transformerEntries
+          .map<String>((value) => value is YamlMap ? value.keys.first : value)
+          .map((value) => value.replaceFirst(RegExp(r'/.*'), '')))
       : <String>{};
   logger.fine('transformers:\n'
       '${bulletItems(packagesUsedViaTransformers)}\n');

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -66,7 +66,7 @@ void run({
   logger.fine('transformers:\n'
       '${bulletItems(packagesUsedViaTransformers)}\n');
 
-  // Recursively list all Dart and Scss files in lib/
+  // Recursively list all Dart, Scss and Less files in lib/
   final publicDartFiles = <File>[]
     ..addAll(listDartFilesIn('lib/', excludedDirs))
     ..addAll(listDartFilesIn('bin/', excludedDirs));
@@ -75,11 +75,17 @@ void run({
     ..addAll(listScssFilesIn('lib/', excludedDirs))
     ..addAll(listScssFilesIn('bin/', excludedDirs));
 
+  final publicLessFiles = <File>[]
+    ..addAll(listLessFilesIn('lib/', excludedDirs))
+    ..addAll(listLessFilesIn('bin/', excludedDirs));
+
   logger
     ..fine('public facing dart files:\n'
         '${bulletItems(publicDartFiles.map((f) => f.path))}\n')
     ..fine('public facing scss files:\n'
-        '${bulletItems(publicScssFiles.map((f) => f.path))}\n');
+        '${bulletItems(publicScssFiles.map((f) => f.path))}\n')
+    ..fine('public facing less files:\n'
+        '${bulletItems(publicLessFiles.map((f) => f.path))}\n');
 
   // Read each file in lib/ and parse the package names from every import and
   // export directive.
@@ -92,6 +98,12 @@ void run({
   }
   for (final file in publicScssFiles) {
     final matches = importScssPackageRegex.allMatches(file.readAsStringSync());
+    for (final match in matches) {
+      packagesUsedInPublicFiles.add(match.group(1));
+    }
+  }
+  for (final file in publicLessFiles) {
+    final matches = importLessPackageRegex.allMatches(file.readAsStringSync());
     for (final match in matches) {
       packagesUsedInPublicFiles.add(match.group(1));
     }
@@ -111,12 +123,19 @@ void run({
     ..addAll(listScssFilesIn('test/', excludedDirs))
     ..addAll(listScssFilesIn('tool/', excludedDirs))
     ..addAll(listScssFilesIn('web/', excludedDirs));
+  final nonLibLessFiles = <File>[]
+    ..addAll(listLessFilesIn('example/', excludedDirs))
+    ..addAll(listLessFilesIn('test/', excludedDirs))
+    ..addAll(listLessFilesIn('tool/', excludedDirs))
+    ..addAll(listLessFilesIn('web/', excludedDirs));
 
   logger
     ..fine('non-lib dart files:\n'
         '${bulletItems(nonLibDartFiles.map((f) => f.path))}\n')
     ..fine('non-lib scss files:\n'
-        '${bulletItems(nonLibScssFiles.map((f) => f.path))}\n');
+        '${bulletItems(nonLibScssFiles.map((f) => f.path))}\n')
+    ..fine('non-lib less files:\n'
+        '${bulletItems(nonLibLessFiles.map((f) => f.path))}\n');
 
   // Read each file outside lib/ and parse the package names from every
   // import and export directive.
@@ -131,6 +150,12 @@ void run({
   }
   for (final file in nonLibScssFiles) {
     final matches = importScssPackageRegex.allMatches(file.readAsStringSync());
+    for (final match in matches) {
+      packagesUsedOutsideLib.add(match.group(1));
+    }
+  }
+  for (final file in nonLibLessFiles) {
+    final matches = importLessPackageRegex.allMatches(file.readAsStringSync());
     for (final match in matches) {
       packagesUsedOutsideLib.add(match.group(1));
     }

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -5,6 +5,10 @@ final RegExp importExportDartPackageRegex =
 /// Regex used to detect all Sass import directives.
 final RegExp importScssPackageRegex = RegExp(r'''\@import\s+['"]{1,3}package:\s*([a-zA-Z0-9_]+)\/[^;]+''');
 
+/// Regex used to detect all Less import directives.
+final RegExp importLessPackageRegex =
+    RegExp(r'@import[\t ]+(?:\(.*\)\s+)?"(?:packages\/|package:\/\/)([a-zA-Z1-9_-]+)\/');
+
 /// String key in pubspec.yaml for the dependencies map.
 const String dependenciesKey = 'dependencies';
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -56,6 +56,13 @@ Iterable<File> listDartFilesIn(String dirPath, List<String> excludedDirs) =>
 Iterable<File> listScssFilesIn(String dirPath, List<String> excludedDirs) =>
     listFilesWithExtensionIn(dirPath, excludedDirs, 'scss');
 
+/// Returns an iterable of all Less files (files ending in .less) in the given
+/// [dirPath] excluding any sub-directories specified in [excludedDirs].
+///
+/// This also excludes Less files that are in a `packages/` subdirectory.
+Iterable<File> listLessFilesIn(String dirPath, List<String> excludedDirs) =>
+    listFilesWithExtensionIn(dirPath, excludedDirs, 'less');
+
 /// Returns an iterable of all files ending in .[extension] in the given
 /// [dirPath] excluding any sub-directories specified in [excludedDirs].
 ///

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -104,6 +104,52 @@ include: package:pedantic/analysis_options.1.8.0.yaml
     }
   });
 
+  group('importLessPackageRegex', () {
+    void sharedTest(String input, String expectedGroup) {
+      expect(input, matches(importLessPackageRegex));
+      expect(importLessPackageRegex.firstMatch(input).group(1), expectedGroup);
+    }
+
+    test('with double-quotes', () {
+      sharedTest('@import "packages/foo/bar";', 'foo');
+      sharedTest('@import "package://foo/bar";', 'foo');
+    });
+
+    group('with a package name that', () {
+      test('contains underscores', () {
+        sharedTest('@import "packages/foo_foo/bar";', 'foo_foo');
+        sharedTest('@import "package://foo_foo/bar";', 'foo_foo');
+      });
+
+      test('contains numbers', () {
+        sharedTest('@import "packages/foo1/bar";', 'foo1');
+        sharedTest('@import "package://foo1/bar";', 'foo1');
+      });
+
+      test('starts with an underscore', () {
+        sharedTest('@import "packages/_foo/bar";', '_foo');
+        sharedTest('@import "package://_foo/bar";', '_foo');
+      });
+    });
+
+    test('with extra whitespace in the line', () {
+      sharedTest('   @import   "packages/foo/bar"   ;   ', 'foo');
+      sharedTest('   @import   "package://foo/bar"   ;   ', 'foo');
+    });
+
+    test('with multiple import\'s in the same line', () {
+      const input = '@import "packages/foo/bar"; @import "package://bar/foo";';
+
+      expect(input, matches(importLessPackageRegex));
+
+      final allMatches = importLessPackageRegex.allMatches(input).toList();
+      expect(allMatches, hasLength(2));
+
+      expect(allMatches[0].group(1), 'foo');
+      expect(allMatches[1].group(1), 'bar');
+    });
+  });
+
   group('importScssPackageRegex', () {
     void sharedTest(String input, String expectedGroup) {
       expect(input, matches(importScssPackageRegex));


### PR DESCRIPTION
## Motivation
Take imports from .less file into account to produce more accurate dependency analysis

## Changes
Read and analyze .less files for imports. Basically same as scss but different file extension and regex.

#### Release Notes
Support .less files analysis

## Review
Please review: @Workviva/app-frameworks

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
- [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct
