### PR TITLE
CPLAT-11300 detect packages that provide one or more executables

### DIFF
--- a/bin/dependency_validator.dart
+++ b/bin/dependency_validator.dart
@@ -52,7 +52,7 @@ void showHelpAndExit() {
   exit(0);
 }
 
-void main(List<String> args) {
+void main(List<String> args) async {
   Logger.root.onRecord
       .where((record) => record.level < Level.WARNING)
       .map((record) => record.message)
@@ -77,5 +77,5 @@ void main(List<String> args) {
     Logger.root.level = Level.ALL;
   }
 
-  run();
+  await run();
 }

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'dart:io';
-import 'dart:convert';
 
 import 'package:glob/glob.dart';
 import 'package:package_config/package_config.dart';
@@ -267,7 +266,7 @@ Future<Null> run() async {
       // Start with all explicitly declared dependencies
       deps
           .union(devDeps)
-          // Remove all deps that provide and executable
+          // Remove all deps that provide an executable
           .difference(packagesWithExecutables)
           // Remove all deps that were used in Dart code somewhere in this package
           .difference(packagesUsedInPublicFiles)

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -22,14 +22,10 @@ const String nameKey = 'name';
 
 /// Packages that are typically only used for their binaries.
 const List<String> commonBinaryPackages = [
-  'build_runner',
   'build_test',
   'build_vm_compilers',
   'build_web_compilers',
   'built_value_generator',
-  'coverage',
-  'dart_dev',
-  'dart_style',
 ];
 
 /// Provides a set of reasons why version strings might be pins.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -92,6 +92,13 @@ void logDependencyInfractions(String infraction, Iterable<String> dependencies) 
   logger.warning([infraction, bulletItems(sortedDependencies), ''].join('\n'));
 }
 
+/// Logs a info with the given [info] and lists all of the given
+/// [dependencies] under that.
+void logDependencyInfo(String info, Iterable<String> dependencies) {
+  final sortedDependencies = dependencies.toList()..sort();
+  logger.info([info, bulletItems(sortedDependencies), ''].join('\n'));
+}
+
 /// Lists the packages with infractions
 List<String> getDependenciesWithPins(Map dependencies, {List<String> ignoredPackages = const []}) {
   final List<String> infractions = [];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   glob: ^1.2.0
   json_annotation: ^3.0.0
   logging: ^0.11.3+1
+  package_config: ^1.9.3
   path: ^1.4.2
   pub_semver: ^1.4.1
   yaml: ^2.1.13

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -248,8 +248,8 @@ void main() {
         final result = checkProject('${d.sandbox}/unused');
 
         expect(result.exitCode, 1);
-        expect(result.stderr,
-            contains('These packages may be unused, or you may be using executables or assets from these packages:'));
+        expect(
+            result.stderr, contains('These packages may be unused, or you may be using assets from these packages:'));
         expect(result.stderr, contains('fake_project'));
       });
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

There are several popular packages that currently have to be ignored when running dependency_validator because they are only used for the executable(s) they provide. The usage of these executables cannot be reliably detected by scanning project files because they can be run in many different ways, or they may only be run locally and not referenced in code.

## Changes
  <!-- What this PR changes to fix the problem. -->

Look up the source for each dependency in ~/.pub-cache to see a bin/ directory exists and contains exectuable entrypoints. If it does, we can take a conservative approach and refuse to consider that dependency "unused" as its executable(s) could be used.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#manual-testing-criteria
