### PR TITLE
CPLAT-11298 detect builders

### DIFF
--- a/bin/dependency_validator.dart
+++ b/bin/dependency_validator.dart
@@ -16,7 +16,6 @@ import 'dart:io' show exit, stderr, stdout;
 
 import 'package:args/args.dart';
 import 'package:dependency_validator/dependency_validator.dart';
-import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 
 const String helpArg = 'help';

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -52,7 +52,7 @@ Future<Null> run() async {
       ?.toList();
   final excludes = configExcludes ?? <Glob>[];
   logger.fine('excludes:\n${bulletItems(excludes.map((g) => g.pattern))}\n');
-  final ignoredPackages = config?.ignore ?? [];
+  final ignoredPackages = config?.ignore ?? <String>[];
   logger.fine('ignored packages:\n${bulletItems(ignoredPackages)}\n');
 
   // Read and parse the analysis_options.yaml in the current working directory.
@@ -273,26 +273,14 @@ Future<Null> run() async {
             // Remove this package, since we know they're using our executable
             ..remove(dependencyValidatorPackageName);
 
-  {
-    // Find unused packages that provide an executable. We assume those executables are used,
-    // but warn the user in case they are not.
-    final consideredUsed = unusedDependencies.intersection(packagesWithExecutables);
-    if (consideredUsed.isNotEmpty) {
-      log(Level.INFO, 'The following packages contain executables, they are assumed to be used:', consideredUsed);
-    }
-  }
-  // Remove deps that provide an executable, assume that the executable is used
+  // Remove deps that provide executables, those are assumed to be used
+  logIntersection(Level.INFO, 'The following packages contain executables, they are assumed to be used:',
+      unusedDependencies, packagesWithExecutables);
   unusedDependencies.removeAll(packagesWithExecutables);
 
-  {
-    // Find unused packages that provide a builder. We assume those builders are used,
-    // but warn the user in case they are not.
-    final consideredUsed = unusedDependencies.intersection(packagesWithBuilders);
-    if (consideredUsed.isNotEmpty) {
-      log(Level.INFO, 'The following packages contain builders, they are assumed to be used:', consideredUsed);
-    }
-  }
-  // Remove deps that provide a builder, assume that the builder is used
+  // Remove deps that provide builders, those are assumed to be used
+  logIntersection(Level.INFO, 'The following packages contain builders, they are assumed to be used:',
+      unusedDependencies, packagesWithBuilders);
   unusedDependencies.removeAll(packagesWithBuilders);
 
   if (unusedDependencies.contains('analyzer')) {

--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -250,6 +250,7 @@ Future<Null> run() async {
             ..remove(dependencyValidatorPackageName);
 
   // Remove deps that provide builders that will be applied
+  final packageConfig = await findPackageConfig(Directory.current);
   final rootBuildConfig = await BuildConfig.fromBuildConfigDir(pubspec.name, pubspec.dependencies.keys, '.');
   bool rootPackageReferencesDependencyInBuildYaml(String dependencyName) => [
         ...rootBuildConfig.globalOptions.keys,
@@ -273,8 +274,6 @@ Future<Null> run() async {
   unusedDependencies.removeAll(packagesWithConsumedBuilders);
 
   // Remove deps that provide executables, those are assumed to be used
-  final packageConfig = await findPackageConfig(Directory.current);
-
   final packagesWithExecutables = Set<String>();
   for (final package in unusedDependencies.map((name) => packageConfig[name])) {
     // Search for executables, if found we assume they are used

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -20,14 +20,6 @@ const String devDependenciesKey = 'dev_dependencies';
 /// String key in pubspec.yaml for the package name.
 const String nameKey = 'name';
 
-/// Packages that are typically only used for their binaries.
-const List<String> commonBinaryPackages = [
-  'build_test',
-  'build_vm_compilers',
-  'build_web_compilers',
-  'built_value_generator',
-];
-
 /// Provides a set of reasons why version strings might be pins.
 class DependencyPinEvaluation {
   const DependencyPinEvaluation._(this.message, {this.isPin = true});

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -92,6 +92,15 @@ void log(Level level, String message, Iterable<String> dependencies) {
   logger.log(level, [message, bulletItems(sortedDependencies), ''].join('\n'));
 }
 
+/// Logs the given [message] at [level] and lists the intersection of [dependenciesA]
+/// and [dependenciesB] if there is one.
+void logIntersection(Level level, String message, Set<String> dependenciesA, Set<String> dependenciesB) {
+  final intersection = dependenciesA.intersection(dependenciesB);
+  if (intersection.isNotEmpty) {
+    log(level, message, intersection);
+  }
+}
+
 /// Lists the packages with infractions
 List<String> getDependenciesWithPins(Map<String, Dependency> dependencies, {List<String> ignoredPackages = const []}) {
   final List<String> infractions = [];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   args: ^1.5.0
+  build_config: ^0.4.2
   checked_yaml: ^1.0.0
   glob: ^1.2.0
   json_annotation: ^3.0.0
@@ -18,6 +19,7 @@ dependencies:
   package_config: ^1.9.3
   path: ^1.4.2
   pub_semver: ^1.4.1
+  pubspec_parse: ^0.1.5
   yaml: ^2.1.13
 
 dev_dependencies:

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -348,7 +348,7 @@ void main() {
       expect(result.stdout, contains('No fatal infractions found, valid is good to go!'));
     });
 
-    test('passes when dependencies not used in lib provide executables', () async {
+    test('passes when dependencies not used provide executables', () async {
       final pubspec = unindent('''
           name: common_binaries
           version: 0.0.0
@@ -377,7 +377,7 @@ void main() {
       expect(result.stdout, contains('No fatal infractions found, common_binaries is good to go!'));
     });
 
-    test('passes when dependencies not used in lib provide auto applied builders', () async {
+    test('passes when dependencies are not imported but provide auto applied builders', () async {
       final pubspec = unindent('''
           name: common_binaries
           version: 0.0.0
@@ -406,7 +406,7 @@ void main() {
       expect(result.stdout, contains('No fatal infractions found, common_binaries is good to go!'));
     });
 
-    test('passes when dependencies not used in lib provide used builders', () async {
+    test('passes when dependencies are not imported but provide used builders', () async {
       final pubspec = unindent('''
           name: common_binaries
           version: 0.0.0

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -53,11 +53,23 @@ void main() {
               path: ${Directory.current.path}
           ''');
 
+      final fakeProjectBuild = unindent('''
+          builders:
+            someBuilder:
+              import: "package:fake_project/builder.dart"
+              builder_factories: ["someBuilder"]
+              build_extensions: {".dart" : [".woot.g.dart"]}
+              auto_apply: none
+              build_to: cache
+          ''');
+
       await d.dir('fake_project', [
         d.dir('lib', [
           d.file('fake.dart', 'bool fake = true;'),
+          d.file('builder.dart', 'bool fake = true;'),
         ]),
         d.file('pubspec.yaml', fakeProjectPubspec),
+        d.file('build.yaml', fakeProjectBuild),
       ]).create();
     });
 
@@ -336,7 +348,7 @@ void main() {
       expect(result.stdout, contains('No fatal infractions found, valid is good to go!'));
     });
 
-    test('passes when there are unused known common binary packages', () async {
+    test('passes when dependencies not used in lib provide executables', () async {
       final pubspec = unindent('''
           name: common_binaries
           version: 0.0.0
@@ -345,10 +357,6 @@ void main() {
             sdk: '>=2.4.0 <3.0.0'
           dev_dependencies:
             build_runner: ^1.7.1
-            build_test: ^0.10.9
-            build_vm_compilers: ^1.0.3
-            build_web_compilers: ^2.5.1
-            built_value_generator: ^7.0.0
             coverage: any
             dart_dev: ^3.0.0
             dart_style: ^1.3.3
@@ -361,6 +369,70 @@ void main() {
           d.file('fake.dart', 'bool fake = true;'),
         ]),
         d.file('pubspec.yaml', pubspec),
+      ]).create();
+
+      final result = checkProject('${d.sandbox}/common_binaries');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('No fatal infractions found, common_binaries is good to go!'));
+    });
+
+    test('passes when dependencies not used in lib provide auto applied builders', () async {
+      final pubspec = unindent('''
+          name: common_binaries
+          version: 0.0.0
+          private: true
+          environment:
+            sdk: '>=2.4.0 <3.0.0'
+          dev_dependencies:
+            build_test: ^0.10.9
+            build_vm_compilers: ^1.0.3
+            build_web_compilers: ^2.5.1
+            built_value_generator: ^7.0.0
+            dependency_validator:
+              path: ${Directory.current.path}
+          ''');
+
+      await d.dir('common_binaries', [
+        d.dir('lib', [
+          d.file('fake.dart', 'bool fake = true;'),
+        ]),
+        d.file('pubspec.yaml', pubspec),
+      ]).create();
+
+      final result = checkProject('${d.sandbox}/common_binaries');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('No fatal infractions found, common_binaries is good to go!'));
+    });
+
+    test('passes when dependencies not used in lib provide used builders', () async {
+      final pubspec = unindent('''
+          name: common_binaries
+          version: 0.0.0
+          private: true
+          environment:
+            sdk: '>=2.4.0 <3.0.0'
+          dev_dependencies:
+            fake_project:
+              path: ${d.sandbox}/fake_project
+            dependency_validator:
+              path: ${Directory.current.path}
+          ''');
+
+      final build = unindent(r'''
+            targets:
+              $default:
+                builders:
+                  fake_project|someBuilder:
+            ''');
+
+      await d.dir('common_binaries', [
+        d.dir('lib', [
+          d.file('nope.dart', 'bool nope = true;'),
+        ]),
+        d.file('pubspec.yaml', pubspec),
+        d.file('build.yaml', build),
       ]).create();
 
       final result = checkProject('${d.sandbox}/common_binaries');

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -14,6 +14,7 @@
 
 @TestOn('vm')
 
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
@@ -205,95 +206,106 @@ include: package:pedantic/analysis_options.1.8.0.yaml
 
   group('inspectVersionForPins classifies', () {
     test('any', () {
-      expect(inspectVersionForPins('any'), DependencyPinEvaluation.notAPin);
+      expect(inspectVersionForPins(VersionConstraint.parse('any')), DependencyPinEvaluation.notAPin);
     });
 
     test('empty', () {
-      expect(inspectVersionForPins('>0.0.0 <0.0.0'), DependencyPinEvaluation.emptyPin);
+      expect(inspectVersionForPins(VersionConstraint.parse('>0.0.0 <0.0.0')), DependencyPinEvaluation.emptyPin);
     });
 
     test('caret notation', () {
-      expect(inspectVersionForPins('^0.0.1'), DependencyPinEvaluation.notAPin);
-      expect(inspectVersionForPins('^0.2.4'), DependencyPinEvaluation.notAPin);
-      expect(inspectVersionForPins('^1.2.4'), DependencyPinEvaluation.notAPin);
+      expect(inspectVersionForPins(VersionConstraint.parse('^0.0.1')), DependencyPinEvaluation.notAPin);
+      expect(inspectVersionForPins(VersionConstraint.parse('^0.2.4')), DependencyPinEvaluation.notAPin);
+      expect(inspectVersionForPins(VersionConstraint.parse('^1.2.4')), DependencyPinEvaluation.notAPin);
     });
 
     test('1.2.3', () {
-      expect(inspectVersionForPins('1.23.456'), DependencyPinEvaluation.directPin);
+      expect(inspectVersionForPins(VersionConstraint.parse('1.23.456')), DependencyPinEvaluation.directPin);
     });
 
     test('explicit upper bound <=', () {
-      expect(inspectVersionForPins('>=1.2.3 <=4.0.0'), DependencyPinEvaluation.inclusiveMax);
-      expect(inspectVersionForPins('<=4.0.0'), DependencyPinEvaluation.inclusiveMax);
+      expect(inspectVersionForPins(VersionConstraint.parse('>=1.2.3 <=4.0.0')), DependencyPinEvaluation.inclusiveMax);
+      expect(inspectVersionForPins(VersionConstraint.parse('<=4.0.0')), DependencyPinEvaluation.inclusiveMax);
     });
 
     group('when upper bound blocks patch or minor updates', () {
       test('when version starts with 0', () {
-        expect(inspectVersionForPins('>=0.2.3 <0.5.6'), DependencyPinEvaluation.blocksMinorBumps);
-        expect(inspectVersionForPins('<0.5.6'), DependencyPinEvaluation.blocksMinorBumps);
+        expect(
+            inspectVersionForPins(VersionConstraint.parse('>=0.2.3 <0.5.6')), DependencyPinEvaluation.blocksMinorBumps);
+        expect(inspectVersionForPins(VersionConstraint.parse('<0.5.6')), DependencyPinEvaluation.blocksMinorBumps);
       });
 
       test('when version starts with nonzero', () {
-        expect(inspectVersionForPins('>=1.2.3 <4.5.0'), DependencyPinEvaluation.blocksMinorBumps);
-        expect(inspectVersionForPins('<4.5.0'), DependencyPinEvaluation.blocksMinorBumps);
+        expect(
+            inspectVersionForPins(VersionConstraint.parse('>=1.2.3 <4.5.0')), DependencyPinEvaluation.blocksMinorBumps);
+        expect(inspectVersionForPins(VersionConstraint.parse('<4.5.0')), DependencyPinEvaluation.blocksMinorBumps);
 
-        expect(inspectVersionForPins('>=1.2.3 <4.0.6'), DependencyPinEvaluation.blocksPatchReleases);
-        expect(inspectVersionForPins('<4.0.6'), DependencyPinEvaluation.blocksPatchReleases);
+        expect(inspectVersionForPins(VersionConstraint.parse('>=1.2.3 <4.0.6')),
+            DependencyPinEvaluation.blocksPatchReleases);
+        expect(inspectVersionForPins(VersionConstraint.parse('<4.0.6')), DependencyPinEvaluation.blocksPatchReleases);
 
-        expect(inspectVersionForPins('>=1.2.3 <1.2.4'), DependencyPinEvaluation.blocksPatchReleases);
-        expect(inspectVersionForPins('>=1.3.0 <1.4.0'), DependencyPinEvaluation.blocksMinorBumps);
+        expect(inspectVersionForPins(VersionConstraint.parse('>=1.2.3 <1.2.4')),
+            DependencyPinEvaluation.blocksPatchReleases);
+        expect(
+            inspectVersionForPins(VersionConstraint.parse('>=1.3.0 <1.4.0')), DependencyPinEvaluation.blocksMinorBumps);
       });
     });
 
     test('when upper bound does not allow either patch or minor updates', () {
-      expect(inspectVersionForPins('>=1.2.3 <4.5.6'), DependencyPinEvaluation.blocksPatchReleases);
-      expect(inspectVersionForPins('<4.5.6'), DependencyPinEvaluation.blocksPatchReleases);
+      expect(inspectVersionForPins(VersionConstraint.parse('>=1.2.3 <4.5.6')),
+          DependencyPinEvaluation.blocksPatchReleases);
+      expect(inspectVersionForPins(VersionConstraint.parse('<4.5.6')), DependencyPinEvaluation.blocksPatchReleases);
     });
 
     test('when the maximum version is 0.0.X', () {
-      expect(inspectVersionForPins('>=0.0.1 <0.0.2'), DependencyPinEvaluation.blocksMinorBumps);
-      expect(inspectVersionForPins('<0.0.2'), DependencyPinEvaluation.blocksMinorBumps);
+      expect(
+          inspectVersionForPins(VersionConstraint.parse('>=0.0.1 <0.0.2')), DependencyPinEvaluation.blocksMinorBumps);
+      expect(inspectVersionForPins(VersionConstraint.parse('<0.0.2')), DependencyPinEvaluation.blocksMinorBumps);
     });
 
     test('when the maximum bound contains build', () {
-      expect(inspectVersionForPins('>=0.2.0 <0.3.0+1'), DependencyPinEvaluation.buildOrPrerelease);
-      expect(inspectVersionForPins('<0.2.0+1'), DependencyPinEvaluation.buildOrPrerelease);
+      expect(inspectVersionForPins(VersionConstraint.parse('>=0.2.0 <0.3.0+1')),
+          DependencyPinEvaluation.buildOrPrerelease);
+      expect(inspectVersionForPins(VersionConstraint.parse('<0.2.0+1')), DependencyPinEvaluation.buildOrPrerelease);
 
-      expect(inspectVersionForPins('>=1.0.0 <2.0.0+1'), DependencyPinEvaluation.buildOrPrerelease);
-      expect(inspectVersionForPins('<2.0.0+1'), DependencyPinEvaluation.buildOrPrerelease);
+      expect(inspectVersionForPins(VersionConstraint.parse('>=1.0.0 <2.0.0+1')),
+          DependencyPinEvaluation.buildOrPrerelease);
+      expect(inspectVersionForPins(VersionConstraint.parse('<2.0.0+1')), DependencyPinEvaluation.buildOrPrerelease);
     });
 
     group('when the maximum bound contains prerelease', () {
       test('', () {
-        expect(inspectVersionForPins('>=0.2.0 <0.3.0-1'), DependencyPinEvaluation.buildOrPrerelease);
-        expect(inspectVersionForPins('<0.2.0-1'), DependencyPinEvaluation.buildOrPrerelease);
+        expect(inspectVersionForPins(VersionConstraint.parse('>=0.2.0 <0.3.0-1')),
+            DependencyPinEvaluation.buildOrPrerelease);
+        expect(inspectVersionForPins(VersionConstraint.parse('<0.2.0-1')), DependencyPinEvaluation.buildOrPrerelease);
 
-        expect(inspectVersionForPins('>=1.0.0 <2.0.0-1'), DependencyPinEvaluation.buildOrPrerelease);
-        expect(inspectVersionForPins('<2.0.0-1'), DependencyPinEvaluation.buildOrPrerelease);
+        expect(inspectVersionForPins(VersionConstraint.parse('>=1.0.0 <2.0.0-1')),
+            DependencyPinEvaluation.buildOrPrerelease);
+        expect(inspectVersionForPins(VersionConstraint.parse('<2.0.0-1')), DependencyPinEvaluation.buildOrPrerelease);
       });
 
       test('but determines not a pin for prerelease=0', () {
-        expect(inspectVersionForPins('>=0.2.0 <0.3.0-0'), DependencyPinEvaluation.notAPin);
-        expect(inspectVersionForPins('<0.2.0-0'), DependencyPinEvaluation.notAPin);
+        expect(inspectVersionForPins(VersionConstraint.parse('>=0.2.0 <0.3.0-0')), DependencyPinEvaluation.notAPin);
+        expect(inspectVersionForPins(VersionConstraint.parse('<0.2.0-0')), DependencyPinEvaluation.notAPin);
 
-        expect(inspectVersionForPins('>=1.0.0 <2.0.0-0'), DependencyPinEvaluation.notAPin);
-        expect(inspectVersionForPins('<2.0.0-0'), DependencyPinEvaluation.notAPin);
+        expect(inspectVersionForPins(VersionConstraint.parse('>=1.0.0 <2.0.0-0')), DependencyPinEvaluation.notAPin);
+        expect(inspectVersionForPins(VersionConstraint.parse('<2.0.0-0')), DependencyPinEvaluation.notAPin);
       });
     });
 
     group('not a pin when maximum version is', () {
       test('<X.0.0', () {
-        expect(inspectVersionForPins('>=1.0.0 <2.0.0'), DependencyPinEvaluation.notAPin);
-        expect(inspectVersionForPins('<2.0.0'), DependencyPinEvaluation.notAPin);
+        expect(inspectVersionForPins(VersionConstraint.parse('>=1.0.0 <2.0.0')), DependencyPinEvaluation.notAPin);
+        expect(inspectVersionForPins(VersionConstraint.parse('<2.0.0')), DependencyPinEvaluation.notAPin);
       });
 
       test('<0.X.0', () {
-        expect(inspectVersionForPins('>=0.2.0 <0.3.0'), DependencyPinEvaluation.notAPin);
-        expect(inspectVersionForPins('<0.2.0'), DependencyPinEvaluation.notAPin);
+        expect(inspectVersionForPins(VersionConstraint.parse('>=0.2.0 <0.3.0')), DependencyPinEvaluation.notAPin);
+        expect(inspectVersionForPins(VersionConstraint.parse('<0.2.0')), DependencyPinEvaluation.notAPin);
       });
 
       test('unset', () {
-        expect(inspectVersionForPins('>=0.2.0'), DependencyPinEvaluation.notAPin);
+        expect(inspectVersionForPins(VersionConstraint.parse('>=0.2.0')), DependencyPinEvaluation.notAPin);
       });
     });
   });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

There are several popular packages that currently have to be ignored when running dependency_validator because they are only used for the builder they provide, which is something that gets applied automatically when running build_runner and not something we can detect via imports in the source code.

## Changes
  <!-- What this PR changes to fix the problem. -->

Look up the source for each dependency in ~/.pub-cache to see if a build.yaml exists, parse it, and see if any builders are defined. If a dependency defines builder(s), we should consider it "used".

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#manual-testing-criteria
