### PR TITLE
Handle Windows paths when searching for executables

### DIFF
--- a/lib/dependency_validator.dart
+++ b/lib/dependency_validator.dart
@@ -276,7 +276,7 @@ Future<Null> run() async {
   final packagesWithExecutables = Set<String>();
   for (final package in unusedDependencies.map((name) => packageConfig[name])) {
     // Search for executables, if found we assume they are used
-    final binDir = Directory(p.join(package.root.path, 'bin'));
+    final binDir = Directory(p.join(p.fromUri(package.root), 'bin'));
     hasDartFiles() => binDir.listSync().any((entity) => entity.path.endsWith('.dart'));
     if (binDir.existsSync() && hasDartFiles()) {
       packagesWithExecutables.add(package.name);


### PR DESCRIPTION
## Motivation
Allow dependency validator to run on windows. Expanding upon #69 

## Changes
use path.fromUri when searching for executables.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: @evanweible-wf 

### QA Checklist
- [x] Manual testing was performed if needed
Ran dependency_validator on both windows and mac, using the same project and got the same results.


[contributing-review-types]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#manual-testing-criteria
