### PR TITLE
CPLAT-13993: Read config from dart_dependency_validator.yaml if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.0
+
+- Deprecate static configuration in `pubspec.yaml` (because `pub publish` warns
+about unrecognized keys) and instead read it from a
+`dart_dependency_validator.yaml` file when possible.
+
 # 3.0.0
 
 - **Breaking:** removed the public `package:dependency_validator/dependency_validator.dart`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the following to your pubspec.yaml:
 
 ```yaml
 dev_dependencies:
-  dependency_validator: ^2.0.0
+  dependency_validator: ^3.0.0
 ```
 
 ## Usage
@@ -33,15 +33,19 @@ used even if it isn't imported.
 
 There may be packages that are intentionally depended on but not used, or there
 may be directories that need to be ignored. You can statically configure these
-things in your project's `pubspec.yaml`:
+things in a `dart_dependency_validator.yaml` file in the root of your package:
+
 
 ```yaml
-# pubsec.yaml
-dependency_validator:
-  # Exclude one or more paths from being scanned. Supports glob syntax.
-  exclude:
-    - "app/**"
-  # Ignore one or more packages.
-  ignore:
-    - analyzer
+# dart_dependency_validator.yaml
+
+# Exclude one or more paths from being scanned. Supports glob syntax.
+exclude:
+  - "app/**"
+# Ignore one or more packages.
+ignore:
+  - analyzer
 ```
+
+> Note: Previously this configuration lived in the `pubspec.yaml`, but that
+> option was deprecated because `pub publish` warns about unrecognized keys.

--- a/dart_dependency_validator.yaml
+++ b/dart_dependency_validator.yaml
@@ -1,0 +1,8 @@
+ignore:
+  - json_serializable
+  - _foo
+  - foo
+  - _bar
+  - bar
+  - foo1
+  - foo_foo

--- a/lib/src/pubspec_config.dart
+++ b/lib/src/pubspec_config.dart
@@ -11,6 +11,10 @@ part 'pubspec_config.g.dart';
 class PubspecDepValidatorConfig {
   final DepValidatorConfig dependencyValidator;
 
+  bool get isNotEmpty =>
+      dependencyValidator.exclude.isNotEmpty ||
+      dependencyValidator.ignore.isNotEmpty;
+
   PubspecDepValidatorConfig({DepValidatorConfig? dependencyValidator})
       : dependencyValidator = dependencyValidator ?? DepValidatorConfig();
 
@@ -39,4 +43,9 @@ class DepValidatorConfig {
 
   factory DepValidatorConfig.fromJson(Map json) =>
       _$DepValidatorConfigFromJson(json);
+
+  factory DepValidatorConfig.fromYaml(String yamlContent, {sourceUrl}) =>
+      checkedYamlDecode(
+          yamlContent, (m) => DepValidatorConfig.fromJson(m ?? {}),
+          allowNull: true, sourceUrl: sourceUrl);
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -15,6 +15,7 @@
 import 'dart:io';
 
 import 'package:glob/glob.dart';
+import 'package:io/ansi.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -92,7 +93,13 @@ Iterable<File> listFilesWithExtensionIn(
 /// Logs the given [message] at [level] and lists all of the given [dependencies].
 void log(Level level, String message, Iterable<String> dependencies) {
   final sortedDependencies = dependencies.toList()..sort();
-  logger.log(level, [message, bulletItems(sortedDependencies), ''].join('\n'));
+  var combined = [message, bulletItems(sortedDependencies), ''].join('\n');
+  if (level >= Level.SEVERE) {
+    combined = red.wrap(combined)!;
+  } else if (level >= Level.WARNING) {
+    combined = yellow.wrap(combined)!;
+  }
+  logger.log(level, combined);
 }
 
 /// Logs the given [message] at [level] and lists the intersection of [dependenciesA]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   build_config: '>=0.4.2 <2.0.0'
   checked_yaml: ^2.0.1
   glob: ^2.0.1
+  io: ^1.0.0
   json_annotation: ^4.0.1
   logging: ^1.0.1
   package_config: ^2.0.0
@@ -28,13 +29,3 @@ dev_dependencies:
 
 executables:
   dependency_validator:
-
-dependency_validator:
-  ignore:
-    - json_serializable
-    - _foo
-    - foo
-    - _bar
-    - bar
-    - foo1
-    - foo_foo


### PR DESCRIPTION
## Motivation
`pub publish` warns when it finds unrecognized keys, which is problematic because we currently read static config from a `dependency_validator` entry in `pubspec.yaml`.

## Changes
- Deprecate the current static config location within `pubspec.yaml` (the executable now warns when it is used)
- Add support for reading the same config format (without the `dependency_validator:` key) from a `dart_dependency_validator.yaml` file in the root of the package. This name was chosen to match the convention set by the `test` package using a `dart_test.yaml` config file.
- Tests have been updated and both the deprecated and new config codepaths are verified.
