### PR TITLE
Exit with usage code when incorrect args are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.1.1
+# 3.1.2
 
 - Return non-zero exit code from executable when incorrect args are used
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.1
+
+- Return non-zero exit code from executable when incorrect args are used
+
 # 3.1.0
 
 - Deprecate static configuration in `pubspec.yaml` (because `pub publish` warns

--- a/bin/dependency_validator.dart
+++ b/bin/dependency_validator.dart
@@ -16,6 +16,7 @@ import 'dart:io' show exit, stderr, stdout;
 
 import 'package:args/args.dart';
 import 'package:dependency_validator/src/dependency_validator.dart';
+import 'package:io/io.dart';
 import 'package:logging/logging.dart';
 
 const String helpArg = 'help';
@@ -46,10 +47,10 @@ final ArgParser argParser = ArgParser()
     help: 'Display extra information for debugging.',
   );
 
-void showHelpAndExit() {
+void showHelpAndExit({ExitCode exitCode = ExitCode.success}) {
   Logger.root.shout(helpMessage);
   Logger.root.shout(argParser.usage);
-  exit(0);
+  exit(exitCode.code);
 }
 
 void main(List<String> args) async {
@@ -66,7 +67,7 @@ void main(List<String> args) async {
   try {
     argResults = argParser.parse(args);
   } on FormatException catch (_) {
-    showHelpAndExit();
+    showHelpAndExit(exitCode: ExitCode.usage);
   }
 
   if (argResults.wasParsed(helpArg) && argResults[helpArg]) {

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -187,10 +187,10 @@ Future<void> run() async {
           // Remove all explicitly declared dependencies
           .difference(deps)
           .difference(devDeps)
-            // Ignore self-imports - packages have implicit access to themselves.
-            ..remove(pubspec.name)
-            // Ignore known missing packages.
-            ..removeAll(ignoredPackages);
+        // Ignore self-imports - packages have implicit access to themselves.
+        ..remove(pubspec.name)
+        // Ignore known missing packages.
+        ..removeAll(ignoredPackages);
 
   if (missingDependencies.isNotEmpty) {
     log(
@@ -209,10 +209,10 @@ Future<void> run() async {
           // Remove all explicitly declared dependencies
           .difference(devDeps)
           .difference(deps)
-            // Ignore self-imports - packages have implicit access to themselves.
-            ..remove(pubspec.name)
-            // Ignore known missing packages.
-            ..removeAll(ignoredPackages);
+        // Ignore self-imports - packages have implicit access to themselves.
+        ..remove(pubspec.name)
+        // Ignore known missing packages.
+        ..removeAll(ignoredPackages);
 
   if (missingDevDependencies.isNotEmpty) {
     log(
@@ -267,8 +267,8 @@ Future<void> run() async {
           // Remove all deps that were used in Dart code somewhere in this package
           .difference(packagesUsedInPublicFiles)
           .difference(packagesUsedOutsidePublicDirs)
-            // Remove this package, since we know they're using our executable
-            ..remove(dependencyValidatorPackageName);
+        // Remove this package, since we know they're using our executable
+        ..remove(dependencyValidatorPackageName);
 
   final packageConfig = await findPackageConfig(Directory.current);
   if (packageConfig == null) {


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
When non-recognized args are used, we print the help message, but still exit with a `0` exit code. This can cause false positives in CI if legacy command line args are used.
## Changes
  <!-- What this PR changes to fix the problem. -->
* Return appropriate exit code
* Add test
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#manual-testing-criteria
