### PR TITLE
ignored pinned packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0
+
+- Feature: Added option `ignored_pinned_packages` for ignoring pinned packages.
+
 # 3.1.2
 
 - Return non-zero exit code from executable when incorrect args are used

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ things in a `dart_dependency_validator.yaml` file in the root of your package:
 ```yaml
 # dart_dependency_validator.yaml
 
+# Set true if you use pinned dependencies
+ignored_pinned_packages: true
 # Exclude one or more paths from being scanned. Supports glob syntax.
 exclude:
   - "app/**"

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -78,7 +78,9 @@ Future<void> run() async {
 
   logger.info('Validating dependencies for ${pubspec.name}...');
 
-  checkPubspecForPins(pubspec, ignoredPackages: ignoredPackages);
+  if (!config.ignoredPinnedPackages) {
+    checkPubspecForPins(pubspec, ignoredPackages: ignoredPackages);
+  }
 
   // Extract the package names from the `dependencies` section.
   final deps = Set<String>.from(pubspec.dependencies.keys);

--- a/lib/src/pubspec_config.dart
+++ b/lib/src/pubspec_config.dart
@@ -39,7 +39,14 @@ class DepValidatorConfig {
   @JsonKey(defaultValue: [])
   final List<String> ignore;
 
-  const DepValidatorConfig({this.exclude = const [], this.ignore = const []});
+  @JsonKey(defaultValue: false)
+  final bool ignoredPinnedPackages;
+
+  const DepValidatorConfig({
+    this.exclude = const [],
+    this.ignore = const [],
+    this.ignoredPinnedPackages = false,
+  });
 
   factory DepValidatorConfig.fromJson(Map json) =>
       _$DepValidatorConfigFromJson(json);

--- a/lib/src/pubspec_config.g.dart
+++ b/lib/src/pubspec_config.g.dart
@@ -25,7 +25,10 @@ DepValidatorConfig _$DepValidatorConfigFromJson(Map json) {
       ignore: $checkedConvert(json, 'ignore',
               (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()) ??
           [],
+      ignoredPinnedPackages:
+          $checkedConvert(json, 'ignored_pinned_packages', (v) => v as bool?) ??
+              false,
     );
     return val;
-  });
+  }, fieldKeyMap: const {'ignoredPinnedPackages': 'ignored_pinned_packages'});
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -667,6 +667,23 @@ void main() {
                 'These packages are pinned in pubspec.yaml:\n  * logging'));
       });
 
+      test('should not print message about pinned packages if pins are ignored',
+          () async {
+        await d.dir('dependency_pins', [
+          d.file('dart_dependency_validator.yaml', unindent('''
+            ignored_pinned_packages: true
+            '''))
+        ]).create();
+        result = checkProject('${d.sandbox}/dependency_pins');
+        expect(result.exitCode, 1);
+        expect(
+          result.stderr,
+          isNot(
+            contains('These packages are pinned in pubspec.yaml:\n  * logging'),
+          ),
+        );
+      });
+
       test('ignores infractions if the package is ignored', () async {
         await d.dir('dependency_pins', [
           d.file('dart_dependency_validator.yaml', unindent('''


### PR DESCRIPTION
## Motivation
fix https://github.com/Workiva/dependency_validator/issues/83
some projects using pinned packages because:
1) more version control
2) prevent issues with implicit version update, as example https://github.com/dart-lang/sdk/issues/48658

## Changes
  add new option for `dart_dependency_validator.yaml`

#### Release Notes
  - Feature: Added option `ignored_pinned_packages` for ignoring pinned packages.

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dependency_validator/blob/master/CONTRIBUTING.md#manual-testing-criteria
