### PR TITLE
Implemented dart ast parsing for import/export usage

### DIFF
--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -14,7 +14,9 @@
 
 import 'dart:io';
 
+import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:build_config/build_config.dart';
+import 'package:dependency_validator/src/import_export_ast_visitor.dart';
 import 'package:glob/glob.dart';
 import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
@@ -114,11 +116,7 @@ Future<void> run() async {
   // export directive.
   final packagesUsedInPublicFiles = <String>{};
   for (final file in publicDartFiles) {
-    final matches =
-        importExportDartPackageRegex.allMatches(file.readAsStringSync());
-    for (final match in matches) {
-      packagesUsedInPublicFiles.add(match.group(2)!);
-    }
+    packagesUsedInPublicFiles.addAll(getDartDirectivePackageNames(file));
   }
   for (final file in publicScssFiles) {
     final matches = importScssPackageRegex.allMatches(file.readAsStringSync());
@@ -160,11 +158,7 @@ Future<void> run() async {
     if (optionsIncludePackage != null) optionsIncludePackage,
   };
   for (final file in nonPublicDartFiles) {
-    final matches =
-        importExportDartPackageRegex.allMatches(file.readAsStringSync());
-    for (final match in matches) {
-      packagesUsedOutsidePublicDirs.add(match.group(2)!);
-    }
+    packagesUsedOutsidePublicDirs.addAll(getDartDirectivePackageNames(file));
   }
   for (final file in nonPublicScssFiles) {
     final matches = importScssPackageRegex.allMatches(file.readAsStringSync());

--- a/lib/src/import_export_ast_visitor.dart
+++ b/lib/src/import_export_ast_visitor.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+/// Returns the list of package names that are exported and imported into the
+/// provided dart file
+Set<String> getDartDirectivePackageNames(File file) {
+  final parsed = parseString(content: file.readAsStringSync(), path: file.path);
+  final visitor = ImportExportVisitor();
+  parsed.unit.visitChildren(visitor);
+  return visitor.packageNames;
+}
+
+class ImportExportVisitor extends GeneralizingAstVisitor {
+  Set<String> packageNames = {};
+
+  @override
+  void visitDirective(Directive node) {
+    if (node is! UriBasedDirective) return;
+
+    final uri = node.uri.stringValue;
+    if (uri == null) return;
+
+    // ignore relative path imports
+    if (!uri.startsWith('package:')) return;
+
+    final packageParts = uri.substring('package:'.length).split('/');
+    if (packageParts.isEmpty) return; // sanity check, this probably will never happen
+
+    packageNames.add(packageParts.first);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  analyzer: ^5.4.0
   args: ^2.0.0
   build_config: ^1.0.0
   checked_yaml: ^2.0.1

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -403,6 +403,14 @@ void main() {
         expect(result.stderr, contains('fake_project'));
       });
 
+      test('and import is commented out', () async {
+         await d.dir('unused', [
+           d.dir('lib', [
+            d.file('invalid.dart', '// import \'package:fake_project/fake.dart\';'), // commented out import
+          ]),
+        ]).create();
+      });
+
       test('except when they are ignored', () async {
         await d.dir('unused', [
           d.file('dart_dependency_validator.yaml', unindent('''
@@ -501,7 +509,8 @@ void main() {
 
       final validDotDart = ''
           'import \'package:logging/logging.dart\';'
-          'import \'package:fake_project/fake.dart\';';
+          'import \'package:fake_project/fake.dart\';'
+          '// import \'package:does_not_exist/fake.dart\''; // commented out and unused
 
       await d.dir('valid', [
         d.dir('lib', [
@@ -672,7 +681,7 @@ void main() {
         await d.dir('dependency_pins', [
           d.dir('lib', [
             d.file('test.dart', unindent('''
-            "import 'package:logging/logging.dart'; 
+            "import 'package:logging/logging.dart';
             final log = Logger('ExampleLogger');"
             ''')),
           ]),


### PR DESCRIPTION
## Motivation

There's been a long standing bug with dependency_validator, where if an import or export within dart source exists within a commented out code block, it will still be treated as if it was a valid import/export

This PR addresses this issue by implementing ast parsing of the dart files, and selects all package names based off of `Directive` nodes.

Closes #21 

## QA
tbd