### PR TITLE
FEA-3685: Reverted non-dev bin import usage errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+- Reverted "non-dev packages that are only used within bin/", this was an invalid assumption and would cause
+failures for any consumer which treats `/bin` as apart of the public api.
+
 # 4.0.0
 
 - **Breaking Change:** Added "non-dev packages that are only used within bin/" check to cover this edge case.

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -311,19 +311,6 @@ Future<void> run() async {
       return binDir.listSync().any((entity) => entity.path.endsWith('.dart'));
     }).toSet();
 
-  final nonDevPackagesWithExecutables = packagesWithExecutables
-    .where(pubspec.dependencies.containsKey)
-    .toSet();
-  if (nonDevPackagesWithExecutables.isNotEmpty) {
-    logIntersection(
-      Level.WARNING,
-      'The following packages contain executables, and are only used outside of lib/. These should be downgraded to dev_dependencies:',
-      unusedDependencies,
-      nonDevPackagesWithExecutables,
-    );
-    exitCode = 1;
-  }
-
   logIntersection(
     Level.INFO,
     'The following packages contain executables, they are assumed to be used:',

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -576,40 +576,6 @@ void main() {
       expect(result.stdout, contains('No dependency issues found!'));
     });
 
-    test('fails when dependencies not used provide executables, but are not dev_dependencies', () async {
-      final pubspec = unindent('''
-          name: common_binaries
-          version: 0.0.0
-          private: true
-          environment:
-            sdk: '>=2.12.0 <4.0.0'
-          dependencies:
-            build_runner: ^2.3.3
-            coverage: any
-            dart_style: ^2.3.2
-            dependency_validator:
-              path: ${Directory.current.path}
-          dependency_overrides:
-            build_config:
-              git:
-                url: https://github.com/dart-lang/build.git
-                path: build_config
-                ref: $buildConfigRef
-          ''');
-
-      await d.dir('common_binaries', [
-        d.dir('lib', [
-          d.file('fake.dart', 'bool fake = true;'),
-        ]),
-        d.file('pubspec.yaml', pubspec),
-      ]).create();
-
-      result = checkProject('${d.sandbox}/common_binaries');
-
-      expect(result.exitCode, 1);
-      expect(result.stderr, contains('The following packages contain executables, and are only used outside of lib/. These should be downgraded to dev_dependencies'));
-    });
-
     test(
         'passes when dependencies are not imported but provide auto applied builders',
         () async {


### PR DESCRIPTION
# [FEA-3685](https://jira.atl.workiva.net/browse/FEA-3685)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEA-3685)

## Motivation

One of the new checks within v4 included an invalid assumption: https://github.com/Workiva/dependency_validator/pull/107

This is simply not true, non-dev dependencies can exist within `bin`, I was mistaken on the original intent of #106 

## Changes

Reverted the bad assumption

## Testing/QA Instructions
-