### PR TITLE
Revert "FEA-3685: Reverted non-dev bin import usage errors"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 4.0.1
-- Reverted "non-dev packages that are only used within bin/", this was an invalid assumption and would cause
-failures for any consumer which treats `/bin` as apart of the public api.
-
 # 4.0.0
 
 - **Breaking Change:** Added "non-dev packages that are only used within bin/" check to cover this edge case.

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -311,6 +311,19 @@ Future<void> run() async {
       return binDir.listSync().any((entity) => entity.path.endsWith('.dart'));
     }).toSet();
 
+  final nonDevPackagesWithExecutables = packagesWithExecutables
+    .where(pubspec.dependencies.containsKey)
+    .toSet();
+  if (nonDevPackagesWithExecutables.isNotEmpty) {
+    logIntersection(
+      Level.WARNING,
+      'The following packages contain executables, and are only used outside of lib/. These should be downgraded to dev_dependencies:',
+      unusedDependencies,
+      nonDevPackagesWithExecutables,
+    );
+    exitCode = 1;
+  }
+
   logIntersection(
     Level.INFO,
     'The following packages contain executables, they are assumed to be used:',

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -576,6 +576,40 @@ void main() {
       expect(result.stdout, contains('No dependency issues found!'));
     });
 
+    test('fails when dependencies not used provide executables, but are not dev_dependencies', () async {
+      final pubspec = unindent('''
+          name: common_binaries
+          version: 0.0.0
+          private: true
+          environment:
+            sdk: '>=2.12.0 <4.0.0'
+          dependencies:
+            build_runner: ^2.3.3
+            coverage: any
+            dart_style: ^2.3.2
+            dependency_validator:
+              path: ${Directory.current.path}
+          dependency_overrides:
+            build_config:
+              git:
+                url: https://github.com/dart-lang/build.git
+                path: build_config
+                ref: $buildConfigRef
+          ''');
+
+      await d.dir('common_binaries', [
+        d.dir('lib', [
+          d.file('fake.dart', 'bool fake = true;'),
+        ]),
+        d.file('pubspec.yaml', pubspec),
+      ]).create();
+
+      result = checkProject('${d.sandbox}/common_binaries');
+
+      expect(result.exitCode, 1);
+      expect(result.stderr, contains('The following packages contain executables, and are only used outside of lib/. These should be downgraded to dev_dependencies'));
+    });
+
     test(
         'passes when dependencies are not imported but provide auto applied builders',
         () async {


### PR DESCRIPTION
Reverts Workiva/dependency_validator#115

I was wrong, it was correctly implemented and completely thought I had implemented a different feature