### PR TITLE
Update analyzer constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^5.4.0
+  analyzer: '>=5.4.0 <7.0.0'
   args: ^2.0.0
   build_config: ^1.0.0
   checked_yaml: ^2.0.1


### PR DESCRIPTION
## Motivation
  I noticed analyzer was being resolved to a lower version than available, it's causing warnings in the build runner for freezed.

## Changes
  I opened the depended-on analyzer versions to include the 6.#.# major release, but less than 7.#.# (Not out yet anyway)

## Testing/QA Instructions
  I have no idea the implications this may have, and have not looked around this code base. From my testing, everything is operating normally as far as I can see, but this would need a maintainer to run some tests to confirm. I checked the changes in the analyzer package version notes, they seem minimal and I'm guessing won't affect anything with this package :)