### PR TITLE
Fixed broken GHA and updated installation instructions

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -31,7 +31,9 @@ jobs:
         run: dart analyze
       - name: Run tests
         run: dart test
+
       - uses: anchore/sbom-action@v0
+        if: ${{ matrix.sdk == '2.19.6'}}
         with:
           path: ./
           format: cyclonedx-json

--- a/README.md
+++ b/README.md
@@ -4,17 +4,14 @@
 
 ## Installation
 
-Add the following to your pubspec.yaml:
-
-```yaml
-dev_dependencies:
-  dependency_validator: ^3.0.0
+```
+dart pub global activate dependency_validator
 ```
 
 ## Usage
 
 ```bash
-dart run dependency_validator
+dart pub global run dependency_validator
 ```
 
 This will report any missing, under-promoted, over-promoted, and unused


### PR DESCRIPTION
## Motivation

The best practice suggestion is to install dependency_validator globally, instead of including it within the pubspec.yaml as a dev_dependency

## Changes
- Updated the readme to explain the best practice installation method, installing it globally
- Fixed gha bug where sbom was failing due to being ran twice

## Testing/QA Instructions
- [ ] Verify that the sbom is still included in the gha artifacts