### PR TITLE
FEA-3927: Updated changelog for v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.0
+
+- Update specified analyzer range to support `v6.0.0+`. This supports dependency_validator running on dart 3 better
+
 # 4.0.0
 
 - **Breaking Change:** Added "non-dev packages that are only used within bin/" check to cover this edge case.


### PR DESCRIPTION
# [FEA-3927](https://jira.atl.workiva.net/browse/FEA-3927)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEA-3927)

## Motivation
Rosie went rogue and merge https://github.com/Workiva/dependency_validator/pull/123 before I could update the changelog

## Changes
Updates the changelog to include the updates for v4.1.0, so we can get a successful pub publish

## Testing/QA Instructions
- CI passes