### PR TITLE
FEDX-1589: Include file path on parse error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,7 @@ jobs:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.5
 
   checks:
-    strategy:
-      matrix:
-        sdk: [2.19.6, stable]
     uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.5
-    with:
-      sdk: ${{ matrix.sdk }}
 
   unit-tests:
     strategy:

--- a/lib/src/import_export_ast_visitor.dart
+++ b/lib/src/import_export_ast_visitor.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
@@ -7,7 +8,14 @@ import 'package:analyzer/dart/ast/visitor.dart';
 /// Returns the list of package names that are exported and imported into the
 /// provided dart file
 Set<String> getDartDirectivePackageNames(File file) {
-  final parsed = parseString(content: file.readAsStringSync(), path: file.path);
+  ParseStringResult parsed;
+  try {
+    parsed = parseString(content: file.readAsStringSync(), path: file.path);
+  } catch(e) {
+    print('Error parsing: ${file.path}');
+    exit(1);
+  }
+
   final visitor = ImportExportVisitor();
   parsed.unit.visitChildren(visitor);
   return visitor.packageNames;

--- a/lib/src/import_export_ast_visitor.dart
+++ b/lib/src/import_export_ast_visitor.dart
@@ -11,8 +11,9 @@ Set<String> getDartDirectivePackageNames(File file) {
   ParseStringResult parsed;
   try {
     parsed = parseString(content: file.readAsStringSync(), path: file.path);
-  } catch(e) {
+  } on ArgumentError catch (e) {
     print('Error parsing: ${file.path}');
+    print(e.message);
     exit(1);
   }
 


### PR DESCRIPTION
# [FEDX-1589](https://jira.atl.workiva.net/browse/FEDX-1589)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1589)

## Motivation
If dependency_validator is ran on a file which contains invalid dart syntax, it will fail without a very good message

![Screenshot 2024-09-04 at 7 37 35 PM](https://github.com/user-attachments/assets/7f210453-bb1a-43c1-90cc-5368add3fc41)


## Changes
Updates the output of the parse error, including the name of the file that could not be parsed

![Screenshot 2024-09-04 at 7 41 05 PM](https://github.com/user-attachments/assets/ab7dcbe3-2bcf-4747-bc32-29b81ed4be36)


## Testing/QA Instructions
- [ ] Run dependency_validator against a dart file with invalid dart syntax, verify that the output contains a path to the file which has the error (see above)