### PR TITLE
RM-263537 Release dependency_validator 4.1.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.5
 
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@fixed_validate-publish-condition
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.5
 
   unit-tests:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.5
 
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.5
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@fixed_validate-publish-condition
 
   unit-tests:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.1
+
+- Update the output of parse failures to include the path to the file which failed to parse
+
 # 4.1.0
 
 - Update specified analyzer range to support `v6.0.0+`. This supports dependency_validator running on dart 3 better

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 4.1.0
+version: 4.1.1
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEA-3927: Updated changelog for v4.1.0](https://github.com/Workiva/dependency_validator/pull/124)
	* [fedx_codeowners_file](https://github.com/Workiva/dependency_validator/pull/126)
	* [FEDX-1587: implemented gha-dart-oss](https://github.com/Workiva/dependency_validator/pull/127)
	* [FEDX-1589: Include file path on parse error](https://github.com/Workiva/dependency_validator/pull/128)


Requested by: @matthewnitschke-wk

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dependency_validator/compare/4.1.0...Workiva:release_dependency_validator_4.1.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/dependency_validator/compare/4.1.0...4.1.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5160374167404544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5160374167404544/?repo_name=Workiva%2Fdependency_validator&pull_number=129)