### PR TITLE
Reset the version of dependency_validator

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 5.0.0
+version: 4.1.2
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 


### PR DESCRIPTION
## Motivation

A previous PR manually bumped the pubspec.yaml version of dependency_validator. We do this via our bot "rosie" which was erroring in this release since there was nothing to change

## Changes
Reset the version back to `4.1.2` so rosie will be able to re-bump to `v5` in the release PR

## Testing/QA Instructions
- [ ] CI passes should be sufficient