### PR TITLE
RM-302023 Release dependency_validator 5.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 4.1.2
+version: 5.0.0
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 


### PR DESCRIPTION

Pull Requests included in release:
* Major changes:
	* [Support Pub Workspaces](https://github.com/Workiva/dependency_validator/pull/138)
* Patch changes:
	* [FEDX-2363: Reset the version of dependency_validator](https://github.com/Workiva/dependency_validator/pull/142)


Requested by: @matthewnitschke-wk

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dependency_validator/compare/4.1.2...Workiva:release_dependency_validator_5.0.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/dependency_validator/compare/4.1.2...5.0.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5160374167404544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5160374167404544/?repo_name=Workiva%2Fdependency_validator&pull_number=143)