### PR TITLE
Updated changelog to fix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 5.0.2
+
+- Fixed changelog entries caused from mis-configured auto-release
+
+# 5.0.1
+
+- Fixed analyzer version constraint which was no longer compatable with the specified dart sdk
+
 # 5.0.0
 
 - **Breaking change**: Requires Dart 3.0 or above


### PR DESCRIPTION
## Motivation

Auto-merge of release PRs was implemented causing rosie to automatically merge the release PR before the changelog could be updated. This broke pub.dev publishing, but still bumped the tag

## Changes

- Manually updates the changelog to include the documentation on the latest changes. Also, RMConsole has been updated to no longer auto-merge release PRs, as well as make `validate-publish` a required workflow (preventing this issue in the future)

## Testing/QA Instructions
- [ ] CI passes