### PR TITLE
FEDX-2722: Update the `ignore` field to ignore everything, not just specific checks

### DIFF
--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -310,18 +310,6 @@ Future<void> run() async {
     return binDir.listSync().any((entity) => entity.path.endsWith('.dart'));
   }).toSet();
 
-  final nonDevPackagesWithExecutables =
-      packagesWithExecutables.where(pubspec.dependencies.containsKey).toSet();
-  if (nonDevPackagesWithExecutables.isNotEmpty) {
-    logIntersection(
-      Level.WARNING,
-      'The following packages contain executables, and are only used outside of lib/. These should be downgraded to dev_dependencies:',
-      unusedDependencies,
-      nonDevPackagesWithExecutables,
-    );
-    exitCode = 1;
-  }
-
   logIntersection(
     Level.INFO,
     'The following packages contain executables, they are assumed to be used:',
@@ -346,6 +334,18 @@ Future<void> run() async {
       Level.WARNING,
       'These packages may be unused, or you may be using assets from these packages:',
       unusedDependencies,
+    );
+    exitCode = 1;
+  }
+
+  final nonDevPackagesWithExecutables =
+      packagesWithExecutables.where(pubspec.dependencies.containsKey).toSet();
+  if (nonDevPackagesWithExecutables.isNotEmpty) {
+    logIntersection(
+      Level.WARNING,
+      'The following packages contain executables, and are only used outside of lib/. These should be downgraded to dev_dependencies:',
+      unusedDependencies,
+      nonDevPackagesWithExecutables,
     );
     exitCode = 1;
   }


### PR DESCRIPTION
# [FEDX-2722](https://jira.atl.workiva.net/browse/FEDX-2722)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-2722)

## Motivation

Currently, the `ignore` field only applies to some rules in the dependency_validator execution process

If you're explicitly ignoring a dependency, it doesn't make sense that _some_ rules can still fail. As such, this PR changes the expectation of evaluation, where when `ignore` exists for a package, its full ignored from dep evaluation

> [!TIP]
> Note, this PR's base is `v4` and not `master`
>
> We need to backpatch the v4 version with this change, and this will be manually released once merged into v4. We will create a similar PR in master so the functionality between these branches doesn't change  

## Testing/QA Instructions
- [ ] Consume in a package that fails the "The following packages contain executables, and are only used outside of lib/. These should be downgraded to dev_dependencies:" rule, and ensure that adding `ignore` indeed ignores it