### PR TITLE
FEDX-2723: correctly ignore unused deps

### DIFF
--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -310,7 +310,8 @@ Future<bool> checkPackage({required String root}) async {
       .difference(packagesUsedInPublicFiles)
       .difference(packagesUsedOutsidePublicDirs)
     // Remove this package, since we know they're using our executable
-    ..remove(dependencyValidatorPackageName);
+    ..remove(dependencyValidatorPackageName)
+    ..removeAll(ignoredPackages);
 
   final packageConfig = await findPackageConfig(Directory.current);
   if (packageConfig == null) {
@@ -399,9 +400,6 @@ Future<bool> checkPackage({required String root}) async {
       ),
     );
   }
-
-  // Ignore known unused packages
-  unusedDependencies.removeAll(ignoredPackages);
 
   if (unusedDependencies.isNotEmpty) {
     log(

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -303,15 +303,15 @@ Future<bool> checkPackage({required String root}) async {
 
   // Packages that are not used anywhere but are dependencies.
   final unusedDependencies =
-  // Start with all explicitly declared dependencies
-  deps
-      .union(devDeps)
-      // Remove all deps that were used in Dart code somewhere in this package
-      .difference(packagesUsedInPublicFiles)
-      .difference(packagesUsedOutsidePublicDirs)
-    // Remove this package, since we know they're using our executable
-    ..remove(dependencyValidatorPackageName)
-    ..removeAll(ignoredPackages);
+      // Start with all explicitly declared dependencies
+      deps
+          .union(devDeps)
+          // Remove all deps that were used in Dart code somewhere in this package
+          .difference(packagesUsedInPublicFiles)
+          .difference(packagesUsedOutsidePublicDirs)
+        // Remove this package, since we know they're using our executable
+        ..remove(dependencyValidatorPackageName)
+        ..removeAll(ignoredPackages);
 
   final packageConfig = await findPackageConfig(Directory.current);
   if (packageConfig == null) {


### PR DESCRIPTION
# [FEDX-2723](https://jira.atl.workiva.net/browse/FEDX-2723)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-2723)

## Motivation

We backpatched this pr: https://github.com/Workiva/dependency_validator/pull/148, to v4.1.3, and want to apply the same change to master to prevent functional regressions with the latest release

## Changes

Applies the same `ignore` specification, where anything ignored, is fully ignored

## Testing/QA Instructions
- [ ] Same QA should be sufficient