### PR TITLE
RM-307870 Release dependency_validator 5.0.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 5.0.2
+version: 5.0.3
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEDX-2777: Fixed formatting](https://github.com/Workiva/dependency_validator/pull/151)
	* [FEDX-2723: correctly ignore unused deps](https://github.com/Workiva/dependency_validator/pull/152)
	* [Bump Workiva/gha-dart-oss from 0.1.7 to 0.1.9 in the gha group](https://github.com/Workiva/dependency_validator/pull/154)
	* [Bump analyzer from 7.7.1 to 8.1.1 in the major group](https://github.com/Workiva/dependency_validator/pull/157)


Requested by: @matthewnitschke-wk

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dependency_validator/compare/5.0.2...Workiva:release_dependency_validator_5.0.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/dependency_validator/compare/5.0.2...5.0.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5160374167404544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5160374167404544/?repo_name=Workiva%2Fdependency_validator&pull_number=161)