### PR TITLE
RM-361227 Release dependency_validator 5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+<!-- Add unreleased changes here -->
+
+# 5.0.4
 
 <!-- Add unreleased changes here -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 # 5.0.4
 
+- Allow up to analyzer 10
+
 <!-- Add unreleased changes here -->
 
 # 5.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 5.0.3
+version: 5.0.4
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump the gha group with 4 updates](https://github.com/Workiva/dependency_validator/pull/170)
	* [Bump the major group across 1 directory with 3 updates](https://github.com/Workiva/dependency_validator/pull/174)


Requested by: @robbecker-wf

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dependency_validator/compare/5.0.3...Workiva:release_dependency_validator_5.0.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/dependency_validator/compare/5.0.3...5.0.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5160374167404544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5160374167404544/?repo_name=Workiva%2Fdependency_validator&pull_number=175)