### PR TITLE
RM-379823 Release dependency_validator 5.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 <!-- Add unreleased changes here -->
 
 # 5.0.5
-<!-- Add unreleased changes here -->
+
+- Allow up to analyzer 12
 
 # 5.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 <!-- Add unreleased changes here -->
 
+# 5.0.5
+<!-- Add unreleased changes here -->
+
 # 5.0.4
 
 - Allow up to analyzer 10

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 5.0.4
+version: 5.0.5
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump analyzer from 10.2.0 to 12.0.0 in the major group](https://github.com/Workiva/dependency_validator/pull/177)


Requested by: @robbecker-wf

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dependency_validator/compare/5.0.4...Workiva:release_dependency_validator_5.0.5
Diff Between Last Tag and New Tag: https://github.com/Workiva/dependency_validator/compare/5.0.4...5.0.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5160374167404544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5160374167404544/?repo_name=Workiva%2Fdependency_validator&pull_number=178)