### PR TITLE
RM-389033 Release dependency_validator 5.0.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,14 +10,14 @@ jobs:
   build:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.14
     with:
-      sdk: stable
+      sdk: 3.7.2 # mirrors .tool-versions
 
   checks:
     uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.14
     with:
-      sdk: stable
+      sdk: 3.7.2 # mirrors .tool-versions
 
   unit-tests:
     uses: Workiva/gha-dart-oss/.github/workflows/test-unit.yaml@v0.1.14
     with:
-      sdk: stable
+      sdk: 3.7.2 # mirrors .tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 <!-- Add unreleased changes here -->
 
 # 5.0.6
-<!-- Add unreleased changes here -->
+
+- Allow up to analyzer 13
 
 # 5.0.5
 
@@ -11,8 +12,6 @@
 # 5.0.4
 
 - Allow up to analyzer 10
-
-<!-- Add unreleased changes here -->
 
 # 5.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 <!-- Add unreleased changes here -->
 
+# 5.0.6
+<!-- Add unreleased changes here -->
+
 # 5.0.5
 
 - Allow up to analyzer 12

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 5.0.5
+version: 5.0.6
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump analyzer from 12.1.0 to 13.0.0 in the major group](https://github.com/Workiva/dependency_validator/pull/180)


Requested by: @matthewnitschke-wk

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dependency_validator/compare/5.0.5...Workiva:release_dependency_validator_5.0.6
Diff Between Last Tag and New Tag: https://github.com/Workiva/dependency_validator/compare/5.0.5...5.0.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5160374167404544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5160374167404544/?repo_name=Workiva%2Fdependency_validator&pull_number=185)