### PR TITLE
Parse dart files with the SDK version from the pubspec

### DIFF
--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -131,11 +131,16 @@ Future<bool> checkPackage({required String root}) async {
       '${bulletItems(publicLessFiles.map((f) => f.path))}\n',
     );
 
+  // The language version that the dart files of this package are parsed with.
+  final featureSet = featureSetForPubspec(pubspec);
+
   // Read each file in lib/ and parse the package names from every import and
   // export directive.
   final packagesUsedInPublicFiles = <String>{};
   for (final file in publicDartFiles) {
-    packagesUsedInPublicFiles.addAll(getDartDirectivePackageNames(file));
+    packagesUsedInPublicFiles.addAll(
+      getDartDirectivePackageNames(file, featureSet: featureSet),
+    );
   }
   for (final file in publicScssFiles) {
     final matches = importScssPackageRegex.allMatches(file.readAsStringSync());
@@ -201,7 +206,9 @@ Future<bool> checkPackage({required String root}) async {
     if (optionsIncludePackage != null) optionsIncludePackage,
   };
   for (final file in nonPublicDartFiles) {
-    packagesUsedOutsidePublicDirs.addAll(getDartDirectivePackageNames(file));
+    packagesUsedOutsidePublicDirs.addAll(
+      getDartDirectivePackageNames(file, featureSet: featureSet),
+    );
   }
   for (final file in nonPublicScssFiles) {
     final matches = importScssPackageRegex.allMatches(file.readAsStringSync());

--- a/lib/src/import_export_ast_visitor.dart
+++ b/lib/src/import_export_ast_visitor.dart
@@ -1,16 +1,31 @@
 import 'dart:io';
 
+import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+
+import 'utils.dart';
 
 /// Returns the list of package names that are exported and imported into the
-/// provided dart file
-Set<String> getDartDirectivePackageNames(File file) {
+/// provided dart file, which is parsed with the given [featureSet].
+///
+/// See [featureSetForPubspec] for resolving the [featureSet] of the package
+/// that [file] belongs to.
+Set<String> getDartDirectivePackageNames(
+  File file, {
+  required FeatureSet featureSet,
+}) {
   ParseStringResult parsed;
   try {
-    parsed = parseString(content: file.readAsStringSync(), path: file.path);
+    parsed = parseString(
+      content: file.readAsStringSync(),
+      path: file.path,
+      featureSet: featureSet,
+    );
   } on ArgumentError catch (e) {
     print('Error parsing: ${file.path}');
     print(e.message);
@@ -20,6 +35,42 @@ Set<String> getDartDirectivePackageNames(File file) {
   final visitor = ImportExportVisitor();
   parsed.unit.visitChildren(visitor);
   return visitor.packageNames;
+}
+
+/// Returns the [FeatureSet] that matches the Dart SDK version declared by the
+/// `environment: sdk:` constraint of [pubspec].
+///
+/// Falls back to [FeatureSet.latestLanguageVersion] when [pubspec] does not
+/// declare an SDK constraint with a lower bound.
+FeatureSet featureSetForPubspec(Pubspec pubspec) {
+  final languageVersion = _sdkLanguageVersionOf(pubspec);
+  if (languageVersion == null) {
+    logger.fine(
+      'No SDK version found for ${pubspec.name}, '
+      'parsing with the latest language version.',
+    );
+    return FeatureSet.latestLanguageVersion();
+  }
+
+  logger.fine('Using language version $languageVersion for ${pubspec.name}');
+  return FeatureSet.fromEnableFlags2(
+    sdkLanguageVersion: languageVersion,
+    flags: const [],
+  );
+}
+
+/// Returns the language version implied by the `environment: sdk:` constraint
+/// of [pubspec], or null if it has none.
+Version? _sdkLanguageVersionOf(Pubspec pubspec) {
+  final sdkConstraint = pubspec.environment['sdk'];
+
+  // `Version` also implements `VersionRange`, with itself as the lower bound.
+  final minSdkVersion =
+      sdkConstraint is VersionRange ? sdkConstraint.min : null;
+  if (minSdkVersion == null) return null;
+
+  // A language version is only major.minor.
+  return Version(minSdkVersion.major, minSdkVersion.minor, 0);
 }
 
 class ImportExportVisitor extends GeneralizingAstVisitor {


### PR DESCRIPTION
## Problem

`getDartDirectivePackageNames` parsed every dart file with `parseString`'s default feature set, `FeatureSet.latestLanguageVersion()`. Syntax newer than the package's declared SDK constraint was therefore accepted silently, even though the analyzer would reject it in the package it lives in.

## Change

`checkPackage` resolves a `FeatureSet` from the `environment: sdk:` lower bound of the pubspec it already parses (truncated to `major.minor.0`, since a language version has no patch component) and passes it down to `getDartDirectivePackageNames`:

```dart
final featureSet = featureSetForPubspec(pubspec);
...
getDartDirectivePackageNames(file, featureSet: featureSet)
```

- `featureSetForPubspec` falls back to `FeatureSet.latestLanguageVersion()` when there is no SDK lower bound.
- A bare pin (`sdk: 3.0.0`) works too — `Version` implements `VersionRange` with itself as the lower bound.
- Workspace sub-packages get their own feature set, since `checkPackage` already recurses per sub-package.
- `// @dart=x.y` overrides still apply: `parseString` hands the feature set to the scanner as `featureSetForOverriding`.

## Behavior change

A file using syntax newer than its pubspec's SDK lower bound now hits the existing `ArgumentError` path in `getDartDirectivePackageNames`, which prints the diagnostic and exits 1. Such code is genuinely invalid under language versioning, but it is a harder failure than before.

## Testing

- `dart analyze` / `dart format` clean.
- End-to-end against a scratch package containing `sealed class`: with `sdk: ">=2.19.0 <4.0.0"` it now reports `experiment_not_enabled: This requires the 'sealed-class' language feature to be enabled`; with `sdk: ^3.0.0` it parses and validates normally.
- `dart test`: 84 passing. The 4 failures in `test/executable_test.dart` are pre-existing and reproduce identically on unmodified `master` (their fixtures need network access for `pub get`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUxxy3wafsbkdCCRqmZEDd