### PR TITLE
Parse files with the language version the package declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 <!-- Add unreleased changes here -->
 
+- Parse files with the language version the package declares instead of the
+  newest one the analyzer knows about, which may be unreleased and reject
+  valid code
+
 # 5.0.6
 
 - Allow up to analyzer 13

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -90,6 +90,8 @@ Future<bool> checkPackage({required String root}) async {
 
   logger.info('Validating dependencies for ${pubspec.name}...');
 
+  final featureSet = featureSetForSdkConstraint(pubspec.environment['sdk']);
+
   if (!config.allowPins) {
     checkPubspecForPins(pubspec, ignoredPackages: ignoredPackages);
   }
@@ -135,7 +137,9 @@ Future<bool> checkPackage({required String root}) async {
   // export directive.
   final packagesUsedInPublicFiles = <String>{};
   for (final file in publicDartFiles) {
-    packagesUsedInPublicFiles.addAll(getDartDirectivePackageNames(file));
+    packagesUsedInPublicFiles.addAll(
+      getDartDirectivePackageNames(file, featureSet: featureSet),
+    );
   }
   for (final file in publicScssFiles) {
     final matches = importScssPackageRegex.allMatches(file.readAsStringSync());
@@ -201,7 +205,9 @@ Future<bool> checkPackage({required String root}) async {
     if (optionsIncludePackage != null) optionsIncludePackage,
   };
   for (final file in nonPublicDartFiles) {
-    packagesUsedOutsidePublicDirs.addAll(getDartDirectivePackageNames(file));
+    packagesUsedOutsidePublicDirs.addAll(
+      getDartDirectivePackageNames(file, featureSet: featureSet),
+    );
   }
   for (final file in nonPublicScssFiles) {
     final matches = importScssPackageRegex.allMatches(file.readAsStringSync());

--- a/lib/src/import_export_ast_visitor.dart
+++ b/lib/src/import_export_ast_visitor.dart
@@ -1,16 +1,37 @@
 import 'dart:io';
 
+import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+/// Builds the feature set matching the language version a package declares,
+/// the same way the analyzer derives it from the SDK constraint.
+///
+/// Without this, [parseString] falls back to the newest language version the
+/// analyzer knows about, which may be unreleased and reject valid code.
+FeatureSet featureSetForSdkConstraint(VersionConstraint? sdkConstraint) {
+  final min = sdkConstraint is VersionRange ? sdkConstraint.min : null;
+  if (min == null) return FeatureSet.latestLanguageVersion();
+
+  return FeatureSet.fromEnableFlags2(
+    sdkLanguageVersion: Version(min.major, min.minor, 0),
+    flags: const [],
+  );
+}
 
 /// Returns the list of package names that are exported and imported into the
 /// provided dart file
-Set<String> getDartDirectivePackageNames(File file) {
+Set<String> getDartDirectivePackageNames(File file, {FeatureSet? featureSet}) {
   ParseStringResult parsed;
   try {
-    parsed = parseString(content: file.readAsStringSync(), path: file.path);
+    parsed = parseString(
+      content: file.readAsStringSync(),
+      path: file.path,
+      featureSet: featureSet,
+    );
   } on ArgumentError catch (e) {
     print('Error parsing: ${file.path}');
     print(e.message);

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -308,6 +308,30 @@ void main() {
       expect(result.stdout, contains('No dependency issues found!'));
     });
 
+    test('passes when a parameter carries the final modifier', () async {
+      result = await checkProject(
+        dependencies: {"logging": hostedAny},
+        project: [
+          d.dir('lib', [
+            d.file(
+              'main.dart',
+              unindent('''
+              import 'package:logging/logging.dart';
+
+              void log(final Logger logger, {final String message = ''}) {
+                logger.info(message);
+              }
+            '''),
+            ),
+          ]),
+        ],
+      );
+
+      expect(result.stdout, isNot(contains('Error parsing')));
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('No dependency issues found!'));
+    });
+
     test('passes when dependencies not used provide executables', () async {
       result = await checkProject(
         devDependencies: {


### PR DESCRIPTION
### Problem

`getDartDirectivePackageNames` calls `parseString` without a feature set, so it falls back to `FeatureSet.latestLanguageVersion()` — the newest language version the bundled analyzer knows about. With analyzer 13 that version is unreleased, and it rejects the `final` modifier on formal parameters:

```dart
void f(final int a) {}
```

```
Error parsing: ./lib/example.dart
Content produced diagnostics when parsed:
  extraneous_modifier: Can't have modifier 'final' here. - 1:8
```

The run aborts with exit code 1 before a single dependency is checked, on code the SDK analyzer accepts without complaint.

The behaviour arrived with `5.0.6` (`Allow up to analyzer 13`). The parsing code itself is byte-identical to `5.0.5`; only the resolved analyzer changed — `5.0.5` resolves analyzer 12.1.0 and passes, `5.0.6` resolves analyzer 13.3.0 and fails.

Pinning the language version explicitly confirms the cause — the same snippet parses cleanly under every released version:

| feature set | result |
|---|---|
| `latestLanguageVersion()` | fails |
| language 3.9 / 3.10 / 3.11 / 3.12 | passes |

### Why it hits projects that never write `final` on a parameter

`freezed` emits the modifier itself. A declaration containing no `final` at all generates a constructor that does, so every generated file in a `freezed` project fails to parse. In our monorepo five of twelve packages turned red overnight with no source change — CI installs the tool unpinned, so `5.0.6` was picked up automatically.

Excluding generated files via `dart_dependency_validator.yaml` removes the parse errors but defeats the check: dependencies used only from generated code are then reported as unused, which has to be silenced in turn.

### Fix

Derive the feature set from the package's SDK constraint — the same way the analyzer determines a package's language version — and fall back to the previous behaviour when the constraint is missing or unbounded. The feature set is computed once per package and passed into the parse; the parameter is optional, so the public function stays source-compatible.

### Tests

Adds a regression test to `executable_test.dart`: a project whose library uses `final` on both a positional and a named parameter now validates cleanly. The test fails on `master` and passes with this change.

The rest of the suite is unchanged: 4 tests fail both with and without this change on my machine (`+84 -4` either way), so they look unrelated to it.

Suppressing diagnostics with `throwIfDiagnostics: false` was considered and rejected: it would also hide genuinely malformed files. With this change a truly broken file still reports `expected_token` diagnostics as before.