### PR TITLE
FEDX-7266: Support glob patterns in dependency_validator workspace resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 <!-- Add unreleased changes here -->
 
+- Support glob patterns in Pub Workspace resolution (e.g. `packages/*`).
+
 # 5.0.6
 
 - Allow up to analyzer 13

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -80,10 +80,16 @@ Future<bool> checkPackage({required String root}) async {
   );
 
   var subResult = true;
+  final workspaceMembers = pubspec.isWorkspaceRoot
+      ? resolveWorkspaceMembers(root, pubspec.workspace ?? [])
+      : const <String>[];
   if (pubspec.isWorkspaceRoot) {
     logger.fine('In a workspace. Recursing through sub-packages...');
-    for (final package in pubspec.workspace ?? []) {
-      subResult &= await checkPackage(root: '$root/$package');
+    logger.fine(
+      'workspace members:\n${bulletItems(workspaceMembers)}\n',
+    );
+    for (final package in workspaceMembers) {
+      subResult &= await checkPackage(root: p.join(root, package));
       logger.info('');
     }
   }
@@ -157,8 +163,8 @@ Future<bool> checkPackage({required String root}) async {
   final publicDirGlobs = [for (final dir in publicDirs) makeGlob('$dir**')];
 
   final subpackageGlobs = [
-    for (final subpackage in pubspec.workspace ?? [])
-      makeGlob('$root/$subpackage**'),
+    for (final subpackage in workspaceMembers)
+      makeGlob('${p.join(root, subpackage)}**'),
   ];
 
   logger.fine('subpackage globs: $subpackageGlobs');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -15,6 +15,7 @@
 import 'dart:io';
 
 import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
 import 'package:io/ansi.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:logging/logging.dart';
@@ -209,3 +210,39 @@ extension PubspecUtils on Pubspec {
 /// This function removes `./` paths and replaces all `\` with `/`.
 Glob makeGlob(String path) =>
     Glob(p.posix.normalize(path.replaceAll(r'\', '/')));
+
+/// Returns whether [path] looks like a glob pattern.
+bool looksLikeGlob(String path) => Glob.quote(path) != path;
+
+/// Resolves workspace member patterns to concrete package paths.
+///
+/// Glob patterns are expanded to directories beneath [root] that contain a
+/// `pubspec.yaml`, matching how `dart pub` resolves workspace members.
+/// Non-glob entries are returned as-is.
+List<String> resolveWorkspaceMembers(
+  String root,
+  Iterable<String> patterns,
+) {
+  final members = <String>{};
+  for (final pattern in patterns) {
+    final normalized = p.posix.normalize(pattern.replaceAll(r'\', '/'));
+    if (looksLikeGlob(normalized)) {
+      try {
+        final glob = makeGlob(normalized);
+        for (final entity in glob.listSync(root: root)) {
+          if (entity is! Directory) continue;
+          final pubspec = File(p.join(entity.path, 'pubspec.yaml'));
+          if (!pubspec.existsSync()) continue;
+          members.add(
+            p.posix.normalize(p.relative(entity.path, from: root)),
+          );
+        }
+      } on FormatException {
+        // Invalid glob syntax; skip this pattern.
+      }
+    } else {
+      members.add(normalized);
+    }
+  }
+  return members.toList()..sort();
+}

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -74,6 +74,9 @@ Future<void> checkWorkspace({
   required Map<String, Dependency> subpackageDeps,
   required List<d.Descriptor> workspace,
   required List<d.Descriptor> subpackage,
+  List<String> workspaceMembers = const ['subpackage'],
+  String subpackagePath = 'subpackage',
+  List<d.Descriptor> extraDirs = const [],
   DepValidatorConfig? workspaceConfig,
   DepValidatorConfig? subpackageConfig,
   Level logLevel = Level.OFF,
@@ -83,7 +86,7 @@ Future<void> checkWorkspace({
     'workspace',
     environment: requireDart36,
     dependencies: workspaceDeps,
-    workspace: ['subpackage'],
+    workspace: workspaceMembers,
   );
   final subpackagePubspec = Pubspec(
     'subpackage',
@@ -99,7 +102,8 @@ Future<void> checkWorkspace({
         'dart_dependency_validator.yaml',
         jsonEncode(workspaceConfig.toJson()),
       ),
-    d.dir('subpackage', [
+    ...extraDirs,
+    d.dir(subpackagePath, [
       ...subpackage,
       d.file('pubspec.yaml', jsonEncode(subpackagePubspec.toJson())),
       if (subpackageConfig != null)

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -21,6 +21,64 @@ import 'package:dependency_validator/src/constants.dart';
 import 'package:dependency_validator/src/utils.dart';
 
 void main() {
+  group('resolveWorkspaceMembers', () {
+    test('returns literal paths unchanged', () async {
+      await d.dir('root', [
+        d.dir('pkg', [d.file('pubspec.yaml', 'name: pkg')]),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['pkg']),
+        ['pkg'],
+      );
+    });
+
+    test('expands glob patterns to directories with pubspec.yaml', () async {
+      await d.dir('root', [
+        d.dir('packages', [
+          d.dir('foo', [d.file('pubspec.yaml', 'name: foo')]),
+          d.dir('bar', [d.file('pubspec.yaml', 'name: bar')]),
+          d.dir('no_pubspec', []),
+        ]),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']),
+        ['packages/bar', 'packages/foo'],
+      );
+    });
+
+    test('combines glob and literal workspace members', () async {
+      await d.dir('root', [
+        d.dir('packages', [
+          d.dir('foo', [d.file('pubspec.yaml', 'name: foo')]),
+        ]),
+        d.dir('standalone', [d.file('pubspec.yaml', 'name: standalone')]),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', [
+          'packages/*',
+          'standalone',
+        ]),
+        ['packages/foo', 'standalone'],
+      );
+    });
+  });
+
+  group('looksLikeGlob', () {
+    test('detects glob metacharacters', () {
+      expect(looksLikeGlob('packages/*'), isTrue);
+      expect(looksLikeGlob('packages/**'), isTrue);
+      expect(looksLikeGlob('pkg?'), isTrue);
+    });
+
+    test('returns false for literal paths', () {
+      expect(looksLikeGlob('packages/foo'), isFalse);
+      expect(looksLikeGlob('subpackage'), isFalse);
+    });
+  });
+
   group('getAnalysisOptionsIncludePackage', () {
     test('no analysis_options.yaml', () {
       expect(getAnalysisOptionsIncludePackage(path: d.sandbox), isNull);

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -149,4 +149,44 @@ void main() => group('Workspaces', () {
           ),
         );
       });
+
+      group('glob workspace patterns', () {
+        test(
+          'resolves packages/* to subpackages with pubspec.yaml',
+          () => checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            workspaceMembers: ['packages/*'],
+            subpackagePath: 'packages/subpackage',
+            subpackage: usesHttp,
+            subpackageDeps: dependsOnHttp,
+          ),
+        );
+
+        test(
+          'ignores directories without pubspec.yaml',
+          () => checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            workspaceMembers: ['packages/*'],
+            subpackagePath: 'packages/subpackage',
+            extraDirs: [d.dir('packages/no_pubspec', [])],
+            subpackage: usesHttp,
+            subpackageDeps: dependsOnHttp,
+          ),
+        );
+
+        test(
+          'fails when a glob-matched subpackage has an issue',
+          () => checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            workspaceMembers: ['packages/*'],
+            subpackagePath: 'packages/subpackage',
+            subpackage: usesHttp,
+            subpackageDeps: {},
+            matcher: isFalse,
+          ),
+        );
+      });
     });


### PR DESCRIPTION
Opened by @matthewnitschke-wk with the ai-sdlc workflow for FEDX-7266

## Motivation
Dart/Flutter pub workspaces support glob patterns (e.g. `packages/*`) for declaring workspace members, but `dependency_validator` only handled literal paths in the `workspace` field of the pubspec. As a result, workspace configurations using glob patterns did not resolve correctly — sub-packages could be skipped during recursion, and the glob used to exclude sub-package files from the root package's unused-dependency check was built incorrectly. This change adds glob support so workspace resolution matches `dart pub`'s behavior (ref: Workiva/dependency_validator#176).

## Changes
- Added `resolveWorkspaceMembers` and `looksLikeGlob` in `lib/src/utils.dart`. Glob patterns are expanded via `package:glob` to concrete directories under the workspace root that contain a `pubspec.yaml`; literal paths are returned unchanged; invalid glob syntax is caught and skipped.
- Updated `checkPackage` in `lib/src/dependency_validator.dart` to resolve workspace members once (via `resolveWorkspaceMembers`) and reuse the resolved list both for recursing into sub-packages and for constructing the `subpackageGlobs` used to exclude sub-package files from the top-level dependency scan. Path joining now uses `p.join`.
- Added a changelog entry describing the new glob support.
- Extended the `checkWorkspace` test helper (`test/utils.dart`) with `workspaceMembers`, `subpackagePath`, and `extraDirs` options to support testing glob-based workspace layouts.
- Added unit tests for `resolveWorkspaceMembers`/`looksLikeGlob` (`test/utils_test.dart`) and integration tests for glob-based workspace resolution (`test/workspace_test.dart`), covering literal paths, glob expansion, directories without `pubspec.yaml`, and propagation of validation failures from glob-matched sub-packages.

## Testing/QA Instructions
1. Run `dart test` and confirm all tests pass, including the new tests covering glob resolution.
2. Run `dart test test/utils_test.dart --name resolveWorkspaceMembers` to verify glob expansion logic in isolation (literal paths pass through, `packages/*` expands to matching sub-packages with a `pubspec.yaml`, mixed literal/glob patterns resolve correctly).
3. Run `dart test test/workspace_test.dart --name "glob workspace patterns"` to verify end-to-end behavior: a workspace declaring `packages/*` recurses into matching sub-packages, directories without `pubspec.yaml` are ignored, and unused-dependency issues inside a glob-matched sub-package still fail the overall check.
4. CI passing on the above automated tests is sufficient; no additional manual QA steps are required beyond optionally exercising `dependency_validator` against a local workspace using a glob pattern in its `workspace` field.

- [x] This change is covered by sufficient tests (existing or new), OR I have provided a reason for why tests are not necessary
- [x] I have updated the CHANGELOG.md, OR I have provided a reason for why this change doesn't need it

## Intent

Add glob pattern support to workspace member resolution in dependency_validator. Currently, the tool only handles literal paths in workspace configurations, causing issues when workspaces declare members using glob patterns like `packages/*`. This change adds glob expansion via the `package:glob` library, aligning dependency_validator's workspace resolution behavior with `dart pub` and fixing sub-package discovery and unused-dependency checks for glob-based workspace layouts.

## How To QA

1. 1. Run full test suite with `dart test` and confirm all tests pass, including new/updated tests in test/utils_test.dart and test/workspace_test.dart
2. 2. Run `dart test test/utils_test.dart --name resolveWorkspaceMembers` and verify: literal paths pass through unchanged, `packages/*` expands only to directories with pubspec.yaml, and mixed literal/glob patterns resolve correctly
3. 3. Run `dart test test/workspace_test.dart --name "glob workspace patterns"` and confirm: `packages/*` correctly recurses into matching sub-packages, directories without pubspec.yaml are ignored, and unused-dependency issues in glob-matched sub-packages cause overall check to fail
4. 4. Optionally, create a local package with pubspec_workspace.yaml using `workspace: ['packages/*']` and manually verify dependency_validator correctly recurses into glob-matched sub-packages and excludes their files from root package's unused-dependency scan
