### PR TITLE
FEDX-7265: Dependencies used inside hook/ must be regular dependencies, not dev_dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 <!-- Add unreleased changes here -->
 
+- Validate that dependencies used in `hook/` are regular dependencies, not dev_dependencies.
+
 # 5.0.6
 
 - Allow up to analyzer 13

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ used even if it isn't imported.
 
 - Missing: When a dependency is used in the package but not declared in the `pubspec.yaml`
 - Under-promoted: When a dependency is used within `lib/` but only declared as a dev_dependency.
+- Under-promoted (hook): When a dependency is used within `hook/` but only declared as a dev_dependency. Hook scripts run at install time and require regular dependencies.
 - Over-promoted: When a dependency is only used outside `lib/` but declared as a dependency.
 - Unused: When a dependency is not used in the package but declared in the `pubspec.yaml`.
 

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -106,6 +106,7 @@ Future<bool> checkPackage({required String root}) async {
   );
 
   final publicDirs = ['$root/bin/', '$root/lib/'];
+  final hookDirs = ['$root/hook/'];
   logger.fine("Excluding: $excludes");
   final publicDartFiles = [
     for (final dir in publicDirs) ...listDartFilesIn(dir, excludes),
@@ -115,6 +116,15 @@ Future<bool> checkPackage({required String root}) async {
   ];
   final publicLessFiles = [
     for (final dir in publicDirs) ...listLessFilesIn(dir, excludes),
+  ];
+  final hookDartFiles = [
+    for (final dir in hookDirs) ...listDartFilesIn(dir, excludes),
+  ];
+  final hookScssFiles = [
+    for (final dir in hookDirs) ...listScssFilesIn(dir, excludes),
+  ];
+  final hookLessFiles = [
+    for (final dir in hookDirs) ...listLessFilesIn(dir, excludes),
   ];
 
   logger
@@ -129,6 +139,18 @@ Future<bool> checkPackage({required String root}) async {
     ..fine(
       'public facing less files:\n'
       '${bulletItems(publicLessFiles.map((f) => f.path))}\n',
+    )
+    ..fine(
+      'hook dart files:\n'
+      '${bulletItems(hookDartFiles.map((f) => f.path))}\n',
+    )
+    ..fine(
+      'hook scss files:\n'
+      '${bulletItems(hookScssFiles.map((f) => f.path))}\n',
+    )
+    ..fine(
+      'hook less files:\n'
+      '${bulletItems(hookLessFiles.map((f) => f.path))}\n',
     );
 
   // Read each file in lib/ and parse the package names from every import and
@@ -154,7 +176,29 @@ Future<bool> checkPackage({required String root}) async {
     '${bulletItems(packagesUsedInPublicFiles)}\n',
   );
 
+  final packagesUsedInHook = <String>{};
+  for (final file in hookDartFiles) {
+    packagesUsedInHook.addAll(getDartDirectivePackageNames(file));
+  }
+  for (final file in hookScssFiles) {
+    final matches = importScssPackageRegex.allMatches(file.readAsStringSync());
+    for (final match in matches) {
+      packagesUsedInHook.add(match.group(1)!);
+    }
+  }
+  for (final file in hookLessFiles) {
+    final matches = importLessPackageRegex.allMatches(file.readAsStringSync());
+    for (final match in matches) {
+      packagesUsedInHook.add(match.group(1)!);
+    }
+  }
+  logger.fine(
+    'packages used in hook/:\n'
+    '${bulletItems(packagesUsedInHook)}\n',
+  );
+
   final publicDirGlobs = [for (final dir in publicDirs) makeGlob('$dir**')];
+  final hookDirGlobs = [for (final dir in hookDirs) makeGlob('$dir**')];
 
   final subpackageGlobs = [
     for (final subpackage in pubspec.workspace ?? [])
@@ -166,16 +210,19 @@ Future<bool> checkPackage({required String root}) async {
   final nonPublicDartFiles = listDartFilesIn('$root/', [
     ...excludes,
     ...publicDirGlobs,
+    ...hookDirGlobs,
     ...subpackageGlobs,
   ]);
   final nonPublicScssFiles = listScssFilesIn('$root/', [
     ...excludes,
     ...publicDirGlobs,
+    ...hookDirGlobs,
     ...subpackageGlobs,
   ]);
   final nonPublicLessFiles = listLessFilesIn('$root/', [
     ...excludes,
     ...publicDirGlobs,
+    ...hookDirGlobs,
     ...subpackageGlobs,
   ]);
 
@@ -242,11 +289,29 @@ Future<bool> checkPackage({required String root}) async {
     result = false;
   }
 
+  // Packages that are used in hook/ but are not dependencies.
+  final missingHookDependencies =
+      packagesUsedInHook
+          .difference(deps)
+          .difference(devDeps)
+        ..remove(pubspec.name)
+        ..removeAll(ignoredPackages);
+
+  if (missingHookDependencies.isNotEmpty) {
+    log(
+      Level.WARNING,
+      'These packages are used in hook/ but are not dependencies:',
+      missingHookDependencies,
+    );
+    result = false;
+  }
+
   // Packages that are used outside lib/ but are not dev_dependencies.
   final missingDevDependencies =
       // Start with packages _only_ used outside lib/
       packagesUsedOutsidePublicDirs
           .difference(packagesUsedInPublicFiles)
+          .difference(packagesUsedInHook)
           // Remove all explicitly declared dependencies
           .difference(devDeps)
           .difference(deps)
@@ -272,6 +337,8 @@ Future<bool> checkPackage({required String root}) async {
           .difference(packagesUsedInPublicFiles)
           // Intersect with deps that are used outside lib/ (excludes unused deps)
           .intersection(packagesUsedOutsidePublicDirs))
+        // hook/ scripts run at install time and must stay regular dependencies.
+        ..removeAll(packagesUsedInHook)
         // Ignore known over-promoted packages.
         ..removeAll(ignoredPackages);
 
@@ -300,6 +367,19 @@ Future<bool> checkPackage({required String root}) async {
     result = false;
   }
 
+  // Packages that are used in hook/, but are dev_dependencies.
+  final underPromotedHookDependencies =
+      devDeps.intersection(packagesUsedInHook)..removeAll(ignoredPackages);
+
+  if (underPromotedHookDependencies.isNotEmpty) {
+    log(
+      Level.WARNING,
+      'These packages are used in hook/ and should be promoted to actual dependencies:',
+      underPromotedHookDependencies,
+    );
+    result = false;
+  }
+
   // Packages that are not used anywhere but are dependencies.
   final unusedDependencies =
       // Start with all explicitly declared dependencies
@@ -308,6 +388,7 @@ Future<bool> checkPackage({required String root}) async {
           // Remove all deps that were used in Dart code somewhere in this package
           .difference(packagesUsedInPublicFiles)
           .difference(packagesUsedOutsidePublicDirs)
+          .difference(packagesUsedInHook)
         // Remove this package, since we know they're using our executable
         ..remove(dependencyValidatorPackageName)
         ..removeAll(ignoredPackages);

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -150,6 +150,104 @@ void main() {
       );
     });
 
+    group('fails when there are under promoted packages in hook/', () {
+      final devDependencies = {"logging": hostedAny, "yaml": hostedAny};
+
+      final project = [
+        d.dir('hook', [
+          d.file('build.dart', 'import "package:logging/logging.dart";'),
+          d.file('build.scss', '@import "package:yaml/foo";'),
+        ]),
+      ];
+
+      final config = DepValidatorConfig(ignore: ['logging', 'yaml']);
+
+      test('', () async {
+        result = await checkProject(
+          project: project,
+          devDependencies: devDependencies,
+        );
+        expect(result.exitCode, 1);
+        expect(
+          result.stderr,
+          contains(
+            'These packages are used in hook/ and should be promoted to actual dependencies:',
+          ),
+        );
+        expect(result.stderr, contains('logging'));
+        expect(result.stderr, contains('yaml'));
+      });
+
+      test('except when they are ignored', () async {
+        result = await checkProject(
+          project: project,
+          devDependencies: devDependencies,
+          config: config,
+        );
+        expect(result.exitCode, 0);
+      });
+
+      test(
+        'except when they are ignored (deprecated pubspec method)',
+        () async {
+          result = await checkProject(
+            project: project,
+            devDependencies: devDependencies,
+            config: config,
+            embedConfigInPubspec: true,
+          );
+          expect(result.exitCode, 0);
+        },
+      );
+    });
+
+    group('fails when there are packages missing from hook/', () {
+      final project = [
+        d.dir('hook', [
+          d.file('build.dart', 'import "package:yaml/yaml.dart";'),
+        ]),
+      ];
+
+      final excludeHook = DepValidatorConfig(exclude: ['hook/**']);
+      final ignorePackages = DepValidatorConfig(ignore: ['yaml']);
+
+      test('', () async {
+        result = await checkProject(project: project);
+        expect(result.exitCode, 1);
+        expect(
+          result.stderr,
+          contains('These packages are used in hook/ but are not dependencies:'),
+        );
+        expect(result.stderr, contains('yaml'));
+      });
+
+      test('except when hook is excluded', () async {
+        result = await checkProject(project: project, config: excludeHook);
+        expect(result.exitCode, 0);
+        expect(result.stderr, isEmpty);
+      });
+
+      test('except when they are ignored', () async {
+        result = await checkProject(project: project, config: ignorePackages);
+        expect(result.exitCode, 0);
+      });
+    });
+
+    group('passes when hook dependencies are regular dependencies', () {
+      test('', () async {
+        result = await checkProject(
+          project: [
+            d.dir('hook', [
+              d.file('build.dart', 'import "package:path/path.dart";'),
+            ]),
+          ],
+          dependencies: {'path': hostedAny},
+        );
+        expect(result.exitCode, 0);
+        expect(result.stdout, contains('No dependency issues found!'));
+      });
+    });
+
     group('fails when there are under promoted packages', () {
       final devDependencies = {"logging": hostedAny, "yaml": hostedAny};
 


### PR DESCRIPTION
Opened by @matthewnitschke-wk with the ai-sdlc workflow for FEDX-7265

## Motivation
Dependencies imported inside `hook/` directories run at install time by the package manager. If such a dependency is listed only under `dev_dependencies` (or not declared at all), it won't be available when a consuming package installs in production mode, causing hook execution to fail. `dependency_validator` did not previously check `hook/` usage against declared dependencies, allowing this misconfiguration to go undetected.

## Changes
- Added `hookDirs` handling in `lib/src/dependency_validator.dart`, scanning Dart/SCSS/Less files under `hook/` (in addition to the existing `publicDirs` scan for `bin/` and `lib/`).
- Excluded `hook/` from the "non-public" file scan so it isn't double-counted.
- Added a new check flagging packages used in `hook/` but not declared as any dependency ("missing hook dependencies").
- Extended the under-promoted dev_dependency check so packages used only in `hook/` and declared as `dev_dependency` are also flagged, requiring promotion to a regular dependency.
- Updated `README.md` to document the new "Under-promoted (hook)" validation case.
- Added a `CHANGELOG.md` entry describing the new validation.
- Added test coverage in `test/executable_test.dart` for: under-promoted hook dependencies (including ignore-list and deprecated pubspec-config paths), missing hook dependencies (including exclude and ignore paths), and a passing case with correctly declared hook dependencies.

## Testing/QA Instructions
- Run `dart test` and confirm all tests pass, including the new "fails when there are under promoted packages in hook/", "fails when there are packages missing from hook/", and "passes when hook dependencies are regular dependencies" groups.
- Manually verify: create a package with `hook/build.dart` importing a package declared only as a `dev_dependency`; run the validator and confirm it reports the package as needing promotion.
- Manually verify: create a package with `hook/build.dart` importing a package not declared at all; run the validator and confirm it reports the package as "used in hook/ but are not dependencies".
- Confirm that declaring the package as a regular dependency (or adding it to the `ignore` config) clears the failure and the validator reports "No dependency issues found!".
- CI passing on the added/updated tests is sufficient sign-off for this change.

## Jira ticket
FEDX-7265

## Checklist
- [ ] Changes follow the repository's coding standards
- [ ] Tests have been added/updated and pass locally
- [ ] Documentation (README/CHANGELOG) has been updated
- [ ] No breaking changes to public APIs
- [ ] Ready for code review

## Intent

This change extends the dependency_validator to treat the `hook/` directory as a public-facing directory for dependency resolution purposes. Dependencies imported in hook scripts run at install time in production mode, so they must be declared as regular dependencies rather than dev_dependencies or left undeclared. The validator now scans `hook/` for package imports and flags cases where packages are missing or only present as dev_dependencies.

## How To QA

1. 1. Run 'dart test test/executable_test.dart' and confirm all tests pass, including new groups: 'fails when there are under promoted packages in hook/', 'fails when there are packages missing from hook/', and 'passes when hook dependencies are regular dependencies'
2. 2. Create a test package with 'hook/build.dart' importing a package listed only as dev_dependency in pubspec.yaml; run 'dart run dependency_validator' and confirm it fails reporting the package needs promotion from dev_dependency to regular dependency
3. 3. Create a test package with 'hook/build.dart' importing a package not listed in pubspec.yaml at all; run validator and confirm it fails with message 'These packages are used in hook/ but are not dependencies:' listing that package
4. 4. Add the test package to regular dependencies (or add to ignore list in dependency_validator config); re-run validator and confirm it passes with 'No dependency issues found!'
5. 5. Verify README.md and CHANGELOG.md render correctly and describe the new hook-related validation check
