### PR TITLE
FEDX-7265: Dependencies used inside hook/ must be regular dependencies, not dev_dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-# Unreleased
-<!-- Add unreleased changes here -->
+# 6.0.0
 
 - **Breaking Change:** Treat `hook/` as a public-facing directory when validating dependencies. Dependencies imported in hook scripts run at build/link time (dart build, flutter build) and must be regular dependencies, not dev_dependencies.
 This is enabled by default, and will break the execution of dependency_validator if it occurs within the codebase.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 <!-- Add unreleased changes here -->
 
+- Treat `hook/` as a public-facing directory when validating dependencies. Dependencies imported in hook scripts run at install time and must be regular dependencies, not dev_dependencies.
+
 # 5.0.6
 
 - Allow up to analyzer 13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 <!-- Add unreleased changes here -->
 
-- Treat `hook/` as a public-facing directory when validating dependencies. Dependencies imported in hook scripts run at install time and must be regular dependencies, not dev_dependencies.
+- **Breaking Change:** Treat `hook/` as a public-facing directory when validating dependencies. Dependencies imported in hook scripts run at build/link time (dart build, flutter build) and must be regular dependencies, not dev_dependencies.
+This is enabled by default, and will break the execution of dependency_validator if it occurs within the codebase.
+Resolution is to either move the dependency to `dependencies`, or `ignore`/`exclude` it.
 
 # 5.0.6
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ used even if it isn't imported.
 [dart-build]: https://github.com/dart-lang/build
 
 - Missing: When a dependency is used in the package but not declared in the `pubspec.yaml`
-- Under-promoted: When a dependency is used within `lib/` but only declared as a dev_dependency.
+- Under-promoted: When a dependency is used within `lib/`, `bin/`, or `hook/` but only declared as a dev_dependency.
 - Over-promoted: When a dependency is only used outside `lib/` but declared as a dependency.
 - Unused: When a dependency is not used in the package but declared in the `pubspec.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ used even if it isn't imported.
 - Over-promoted: When a dependency is only used outside `lib/`, `bin/`, and `hook/` but declared as a dependency.
 - Unused: When a dependency is not used in the package but declared in the `pubspec.yaml`.
 
-Hook scripts in `hook/` run at build/link time (for example, `dart build` or `flutter build`), so their imports must be regular `dependencies`. Use `ignore` or `exclude` in `dart_dependency_validator.yaml` if a hook-only dependency should not be validated.
+Hook scripts in `hook/` (for example, `build.dart` and `link.dart`) run at build/link time (`dart build`, `flutter build`), so their imports must be regular `dependencies`. To opt out, use `ignore` to suppress warnings for a specific package name (for example, a dev_dependency used only in hooks), or `exclude: ["hook/**"]` to skip scanning the hook directory entirely (which also skips missing-dependency checks in hook files).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ used even if it isn't imported.
 - Over-promoted: When a dependency is only used outside `lib/`, `bin/`, and `hook/` but declared as a dependency.
 - Unused: When a dependency is not used in the package but declared in the `pubspec.yaml`.
 
+Hook scripts in `hook/` run at build/link time (for example, `dart build` or `flutter build`), so their imports must be regular `dependencies`. Use `ignore` or `exclude` in `dart_dependency_validator.yaml` if a hook-only dependency should not be validated.
+
 ## Configuration
 
 There may be packages that are intentionally depended on but not used, or there

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ used even if it isn't imported.
 
 - Missing: When a dependency is used in the package but not declared in the `pubspec.yaml`
 - Under-promoted: When a dependency is used within `lib/`, `bin/`, or `hook/` but only declared as a dev_dependency.
-- Over-promoted: When a dependency is only used outside `lib/` but declared as a dependency.
+- Over-promoted: When a dependency is only used outside `lib/`, `bin/`, and `hook/` but declared as a dependency.
 - Unused: When a dependency is not used in the package but declared in the `pubspec.yaml`.
 
 ## Configuration

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -14,6 +14,16 @@ final RegExp importLessPackageRegex = RegExp(
   r'@import\s+(?:\(.*\)\s+)?"(?:packages\/|package:\/\/)([a-zA-Z1-9_-]+)\/',
 );
 
+/// Directory names treated as public-facing for dependency validation.
+const publicDirNames = ['lib', 'bin', 'hook'];
+
+/// Human-readable list of [publicDirNames], e.g. `lib/, bin/, or hook/`.
+String publicDirsDescription({String conjunction = 'or'}) {
+  final dirs = [for (final name in publicDirNames) '$name/'];
+  if (dirs.length == 1) return dirs.first;
+  return '${dirs.sublist(0, dirs.length - 1).join(', ')}, $conjunction ${dirs.last}';
+}
+
 /// String key in pubspec.yaml for the dependencies map.
 const String dependenciesKey = 'dependencies';
 

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -105,7 +105,7 @@ Future<bool> checkPackage({required String root}) async {
     '${bulletItems(devDeps)}\n',
   );
 
-  final publicDirs = ['$root/bin/', '$root/hook/', '$root/lib/'];
+  final publicDirs = [for (final dir in publicDirNames) '$root/$dir/'];
   logger.fine("Excluding: $excludes");
   final publicDartFiles = [
     for (final dir in publicDirs) ...listDartFilesIn(dir, excludes),
@@ -236,7 +236,7 @@ Future<bool> checkPackage({required String root}) async {
   if (missingDependencies.isNotEmpty) {
     log(
       Level.WARNING,
-      'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
+      'These packages are used in ${publicDirsDescription()} but are not dependencies:',
       missingDependencies,
     );
     result = false;
@@ -258,7 +258,7 @@ Future<bool> checkPackage({required String root}) async {
   if (missingDevDependencies.isNotEmpty) {
     log(
       Level.WARNING,
-      'These packages are used outside lib/, bin/, and hook/ but are not dev_dependencies:',
+      'These packages are used outside ${publicDirsDescription(conjunction: 'and')} but are not dev_dependencies:',
       missingDevDependencies,
     );
     result = false;
@@ -278,7 +278,7 @@ Future<bool> checkPackage({required String root}) async {
   if (overPromotedDependencies.isNotEmpty) {
     log(
       Level.WARNING,
-      'These packages are only used outside lib/, bin/, and hook/ and should be downgraded to dev_dependencies:',
+      'These packages are only used outside ${publicDirsDescription(conjunction: 'and')} and should be downgraded to dev_dependencies:',
       overPromotedDependencies,
     );
     result = false;
@@ -294,7 +294,7 @@ Future<bool> checkPackage({required String root}) async {
   if (underPromotedDependencies.isNotEmpty) {
     log(
       Level.WARNING,
-      'These packages are used in lib/, bin/, or hook/ and should be promoted to actual dependencies:',
+      'These packages are used in ${publicDirsDescription()} and should be promoted to actual dependencies:',
       underPromotedDependencies,
     );
     result = false;
@@ -376,7 +376,7 @@ Future<bool> checkPackage({required String root}) async {
   if (nonDevPackagesWithExecutables.isNotEmpty) {
     logIntersection(
       Level.WARNING,
-      'The following packages contain executables, and are only used outside of lib/. These should be downgraded to dev_dependencies:',
+      'The following packages contain executables, and are only used outside of ${publicDirsDescription(conjunction: 'and')}. These should be downgraded to dev_dependencies:',
       unusedDependencies,
       nonDevPackagesWithExecutables,
     );

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -105,7 +105,7 @@ Future<bool> checkPackage({required String root}) async {
     '${bulletItems(devDeps)}\n',
   );
 
-  final publicDirs = ['$root/bin/', '$root/lib/'];
+  final publicDirs = ['$root/bin/', '$root/hook/', '$root/lib/'];
   logger.fine("Excluding: $excludes");
   final publicDartFiles = [
     for (final dir in publicDirs) ...listDartFilesIn(dir, excludes),
@@ -236,7 +236,7 @@ Future<bool> checkPackage({required String root}) async {
   if (missingDependencies.isNotEmpty) {
     log(
       Level.WARNING,
-      'These packages are used in lib/ but are not dependencies:',
+      'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
       missingDependencies,
     );
     result = false;
@@ -294,7 +294,7 @@ Future<bool> checkPackage({required String root}) async {
   if (underPromotedDependencies.isNotEmpty) {
     log(
       Level.WARNING,
-      'These packages are used in lib/ and should be promoted to actual dependencies:',
+      'These packages are used in lib/, bin/, or hook/ and should be promoted to actual dependencies:',
       underPromotedDependencies,
     );
     result = false;

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -258,7 +258,7 @@ Future<bool> checkPackage({required String root}) async {
   if (missingDevDependencies.isNotEmpty) {
     log(
       Level.WARNING,
-      'These packages are used outside lib/ but are not dev_dependencies:',
+      'These packages are used outside lib/, bin/, and hook/ but are not dev_dependencies:',
       missingDevDependencies,
     );
     result = false;
@@ -278,7 +278,7 @@ Future<bool> checkPackage({required String root}) async {
   if (overPromotedDependencies.isNotEmpty) {
     log(
       Level.WARNING,
-      'These packages are only used outside lib/ and should be downgraded to dev_dependencies:',
+      'These packages are only used outside lib/, bin/, and hook/ and should be downgraded to dev_dependencies:',
       overPromotedDependencies,
     );
     result = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 6.0.0
+version: 5.0.6
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dependency_validator
-version: 5.0.6
+version: 6.0.0
 description: Checks for missing, under-promoted, over-promoted, and unused dependencies.
 homepage: https://github.com/Workiva/dependency_validator
 

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -49,7 +49,7 @@ void main() {
         expect(result.exitCode, 1);
         expect(
           result.stderr,
-          contains('These packages are used in lib/ but are not dependencies:'),
+          contains('These packages are used in lib/, bin/, or hook/ but are not dependencies:'),
         );
         expect(result.stderr, contains('yaml'));
         expect(result.stderr, contains('some_scss_package'));
@@ -171,7 +171,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are used in lib/ and should be promoted to actual dependencies:',
+            'These packages are used in lib/, bin/, or hook/ and should be promoted to actual dependencies:',
           ),
         );
         expect(result.stderr, contains('logging'));
@@ -199,6 +199,76 @@ void main() {
           expect(result.exitCode, 0);
         },
       );
+    });
+
+    group('fails when hook scripts use dev_dependencies', () {
+      final devDependencies = {"yaml": hostedAny};
+      final config = DepValidatorConfig(ignore: ['yaml']);
+
+      final project = [
+        d.dir('hook', [
+          d.file('post_install.dart', 'import "package:yaml/yaml.dart";'),
+        ]),
+      ];
+
+      test('', () async {
+        result = await checkProject(
+          project: project,
+          devDependencies: devDependencies,
+        );
+        expect(result.exitCode, 1);
+        expect(
+          result.stderr,
+          contains(
+            'These packages are used in lib/, bin/, or hook/ and should be promoted to actual dependencies:',
+          ),
+        );
+        expect(result.stderr, contains('yaml'));
+      });
+
+      test('except when they are ignored', () async {
+        result = await checkProject(
+          project: project,
+          devDependencies: devDependencies,
+          config: config,
+        );
+        expect(result.exitCode, 0);
+      });
+    });
+
+    group('passes when hook scripts use regular dependencies', () {
+      test('', () async {
+        result = await checkProject(
+          dependencies: {"yaml": hostedAny},
+          project: [
+            d.dir('hook', [
+              d.file('post_install.dart', 'import "package:yaml/yaml.dart";'),
+            ]),
+          ],
+        );
+        expect(result.exitCode, 0);
+        expect(result.stdout, contains('No dependency issues found!'));
+      });
+    });
+
+    group('fails when hook scripts use undeclared dependencies', () {
+      final project = [
+        d.dir('hook', [
+          d.file('post_install.dart', 'import "package:yaml/yaml.dart";'),
+        ]),
+      ];
+
+      test('', () async {
+        result = await checkProject(project: project);
+        expect(result.exitCode, 1);
+        expect(
+          result.stderr,
+          contains(
+            'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
+          ),
+        );
+        expect(result.stderr, contains('yaml'));
+      });
     });
 
     group('fails when there are unused packages', () {

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -251,12 +251,48 @@ void main() {
       );
     });
 
+    group('fails when hook link scripts use dev_dependencies', () {
+      final devDependencies = {"yaml": hostedAny};
+
+      test('', () async {
+        result = await checkProject(
+          devDependencies: devDependencies,
+          project: [
+            d.dir('hook', [
+              d.file('link.dart', 'import "package:yaml/yaml.dart";'),
+            ]),
+          ],
+        );
+        expect(result.exitCode, 1);
+        expect(
+          result.stderr,
+          contains(
+            'These packages are used in lib/, bin/, or hook/ and should be promoted to actual dependencies:',
+          ),
+        );
+        expect(result.stderr, contains('yaml'));
+      });
+    });
+
     test('passes when hook scripts use regular dependencies', () async {
       result = await checkProject(
         dependencies: {"yaml": hostedAny},
         project: [
           d.dir('hook', [
             d.file('build.dart', 'import "package:yaml/yaml.dart";'),
+          ]),
+        ],
+      );
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('No dependency issues found!'));
+    });
+
+    test('passes when hook link scripts use regular dependencies', () async {
+      result = await checkProject(
+        dependencies: {"yaml": hostedAny},
+        project: [
+          d.dir('hook', [
+            d.file('link.dart', 'import "package:yaml/yaml.dart";'),
           ]),
         ],
       );
@@ -287,22 +323,49 @@ void main() {
       },
     );
 
-    test('fails when hook scripts use undeclared dependencies', () async {
+    group('fails when hook scripts use undeclared dependencies', () {
       final project = [
         d.dir('hook', [
           d.file('build.dart', 'import "package:yaml/yaml.dart";'),
         ]),
       ];
+      final excludeHook = DepValidatorConfig(exclude: ['hook/**']);
 
-      result = await checkProject(project: project);
-      expect(result.exitCode, 1);
-      expect(
-        result.stderr,
-        contains(
-          'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
-        ),
+      test('', () async {
+        result = await checkProject(project: project);
+        expect(result.exitCode, 1);
+        expect(
+          result.stderr,
+          contains(
+            'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
+          ),
+        );
+        expect(result.stderr, contains('yaml'));
+      });
+
+      test('except when hook is excluded', () async {
+        result = await checkProject(project: project, config: excludeHook);
+        expect(result.exitCode, 0);
+        expect(result.stderr, isEmpty);
+      });
+
+      test(
+        'except when hook is excluded (deprecated pubspec method)',
+        () async {
+          result = await checkProject(
+            project: project,
+            config: excludeHook,
+            embedConfigInPubspec: true,
+          );
+          expect(result.exitCode, 0);
+          expect(
+            result.stderr,
+            contains(
+              'Configuring dependency_validator in pubspec.yaml is deprecated',
+            ),
+          );
+        },
       );
-      expect(result.stderr, contains('yaml'));
     });
 
     group('fails when there are unused packages', () {

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -49,7 +49,9 @@ void main() {
         expect(result.exitCode, 1);
         expect(
           result.stderr,
-          contains('These packages are used in lib/, bin/, or hook/ but are not dependencies:'),
+          contains(
+            'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
+          ),
         );
         expect(result.stderr, contains('yaml'));
         expect(result.stderr, contains('some_scss_package'));
@@ -120,7 +122,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are only used outside lib/ and should be downgraded to dev_dependencies:',
+            'These packages are only used outside lib/, bin/, and hook/ and should be downgraded to dev_dependencies:',
           ),
         );
         expect(result.stderr, contains('path'));

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -15,6 +15,7 @@
 @TestOn('vm')
 import 'dart:io';
 
+import 'package:dependency_validator/src/constants.dart';
 import 'package:dependency_validator/src/pubspec_config.dart';
 import 'package:io/io.dart';
 import 'package:test/test.dart';
@@ -50,7 +51,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
+            'These packages are used in ${publicDirsDescription()} but are not dependencies:',
           ),
         );
         expect(result.stderr, contains('yaml'));
@@ -122,7 +123,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are only used outside lib/, bin/, and hook/ and should be downgraded to dev_dependencies:',
+            'These packages are only used outside ${publicDirsDescription(conjunction: 'and')} and should be downgraded to dev_dependencies:',
           ),
         );
         expect(result.stderr, contains('path'));
@@ -173,7 +174,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are used in lib/, bin/, or hook/ and should be promoted to actual dependencies:',
+            'These packages are used in ${publicDirsDescription()} and should be promoted to actual dependencies:',
           ),
         );
         expect(result.stderr, contains('logging'));
@@ -222,7 +223,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are used in lib/, bin/, or hook/ and should be promoted to actual dependencies:',
+            'These packages are used in ${publicDirsDescription()} and should be promoted to actual dependencies:',
           ),
         );
         expect(result.stderr, contains('yaml'));
@@ -236,10 +237,37 @@ void main() {
         );
         expect(result.exitCode, 0);
       });
+
+      test(
+        'except when they are ignored (deprecated pubspec method)',
+        () async {
+          result = await checkProject(
+            project: project,
+            devDependencies: devDependencies,
+            config: config,
+            embedConfigInPubspec: true,
+          );
+          expect(result.exitCode, 0);
+        },
+      );
     });
 
-    group('passes when hook scripts use regular dependencies', () {
-      test('', () async {
+    test('passes when hook scripts use regular dependencies', () async {
+      result = await checkProject(
+        dependencies: {"yaml": hostedAny},
+        project: [
+          d.dir('hook', [
+            d.file('post_install.dart', 'import "package:yaml/yaml.dart";'),
+          ]),
+        ],
+      );
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('No dependency issues found!'));
+    });
+
+    test(
+      'passes when hook-only dependency is not flagged as over-promoted',
+      () async {
         result = await checkProject(
           dependencies: {"yaml": hostedAny},
           project: [
@@ -249,28 +277,33 @@ void main() {
           ],
         );
         expect(result.exitCode, 0);
-        expect(result.stdout, contains('No dependency issues found!'));
-      });
-    });
+        expect(
+          result.stderr,
+          isNot(
+            contains(
+              'These packages are only used outside ${publicDirsDescription(conjunction: 'and')} and should be downgraded to dev_dependencies:',
+            ),
+          ),
+        );
+      },
+    );
 
-    group('fails when hook scripts use undeclared dependencies', () {
+    test('fails when hook scripts use undeclared dependencies', () async {
       final project = [
         d.dir('hook', [
           d.file('post_install.dart', 'import "package:yaml/yaml.dart";'),
         ]),
       ];
 
-      test('', () async {
-        result = await checkProject(project: project);
-        expect(result.exitCode, 1);
-        expect(
-          result.stderr,
-          contains(
-            'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
-          ),
-        );
-        expect(result.stderr, contains('yaml'));
-      });
+      result = await checkProject(project: project);
+      expect(result.exitCode, 1);
+      expect(
+        result.stderr,
+        contains(
+          'These packages are used in ${publicDirsDescription()} but are not dependencies:',
+        ),
+      );
+      expect(result.stderr, contains('yaml'));
     });
 
     group('fails when there are unused packages', () {
@@ -414,7 +447,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'The following packages contain executables, and are only used outside of lib/. These should be downgraded to dev_dependencies',
+            'The following packages contain executables, and are only used outside of ${publicDirsDescription(conjunction: 'and')}. These should be downgraded to dev_dependencies',
           ),
         );
       },

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -15,7 +15,6 @@
 @TestOn('vm')
 import 'dart:io';
 
-import 'package:dependency_validator/src/constants.dart';
 import 'package:dependency_validator/src/pubspec_config.dart';
 import 'package:io/io.dart';
 import 'package:test/test.dart';
@@ -51,7 +50,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are used in ${publicDirsDescription()} but are not dependencies:',
+            'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
           ),
         );
         expect(result.stderr, contains('yaml'));
@@ -123,7 +122,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are only used outside ${publicDirsDescription(conjunction: 'and')} and should be downgraded to dev_dependencies:',
+            'These packages are only used outside lib/, bin/, and hook/ and should be downgraded to dev_dependencies:',
           ),
         );
         expect(result.stderr, contains('path'));
@@ -174,7 +173,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are used in ${publicDirsDescription()} and should be promoted to actual dependencies:',
+            'These packages are used in lib/, bin/, or hook/ and should be promoted to actual dependencies:',
           ),
         );
         expect(result.stderr, contains('logging'));
@@ -210,7 +209,7 @@ void main() {
 
       final project = [
         d.dir('hook', [
-          d.file('post_install.dart', 'import "package:yaml/yaml.dart";'),
+          d.file('build.dart', 'import "package:yaml/yaml.dart";'),
         ]),
       ];
 
@@ -223,7 +222,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'These packages are used in ${publicDirsDescription()} and should be promoted to actual dependencies:',
+            'These packages are used in lib/, bin/, or hook/ and should be promoted to actual dependencies:',
           ),
         );
         expect(result.stderr, contains('yaml'));
@@ -257,7 +256,7 @@ void main() {
         dependencies: {"yaml": hostedAny},
         project: [
           d.dir('hook', [
-            d.file('post_install.dart', 'import "package:yaml/yaml.dart";'),
+            d.file('build.dart', 'import "package:yaml/yaml.dart";'),
           ]),
         ],
       );
@@ -272,7 +271,7 @@ void main() {
           dependencies: {"yaml": hostedAny},
           project: [
             d.dir('hook', [
-              d.file('post_install.dart', 'import "package:yaml/yaml.dart";'),
+              d.file('build.dart', 'import "package:yaml/yaml.dart";'),
             ]),
           ],
         );
@@ -281,7 +280,7 @@ void main() {
           result.stderr,
           isNot(
             contains(
-              'These packages are only used outside ${publicDirsDescription(conjunction: 'and')} and should be downgraded to dev_dependencies:',
+              'These packages are only used outside lib/, bin/, and hook/ and should be downgraded to dev_dependencies:',
             ),
           ),
         );
@@ -291,7 +290,7 @@ void main() {
     test('fails when hook scripts use undeclared dependencies', () async {
       final project = [
         d.dir('hook', [
-          d.file('post_install.dart', 'import "package:yaml/yaml.dart";'),
+          d.file('build.dart', 'import "package:yaml/yaml.dart";'),
         ]),
       ];
 
@@ -300,7 +299,7 @@ void main() {
       expect(
         result.stderr,
         contains(
-          'These packages are used in ${publicDirsDescription()} but are not dependencies:',
+          'These packages are used in lib/, bin/, or hook/ but are not dependencies:',
         ),
       );
       expect(result.stderr, contains('yaml'));
@@ -447,7 +446,7 @@ void main() {
         expect(
           result.stderr,
           contains(
-            'The following packages contain executables, and are only used outside of ${publicDirsDescription(conjunction: 'and')}. These should be downgraded to dev_dependencies',
+            'The following packages contain executables, and are only used outside of lib/, bin/, and hook/. These should be downgraded to dev_dependencies',
           ),
         );
       },

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -21,6 +21,19 @@ import 'package:dependency_validator/src/constants.dart';
 import 'package:dependency_validator/src/utils.dart';
 
 void main() {
+  group('publicDirsDescription', () {
+    test('default conjunction', () {
+      expect(publicDirsDescription(), 'lib/, bin/, or hook/');
+    });
+
+    test('and conjunction', () {
+      expect(
+        publicDirsDescription(conjunction: 'and'),
+        'lib/, bin/, and hook/',
+      );
+    });
+  });
+
   group('getAnalysisOptionsIncludePackage', () {
     test('no analysis_options.yaml', () {
       expect(getAnalysisOptionsIncludePackage(path: d.sandbox), isNull);


### PR DESCRIPTION
Opened by Dustin Pauze with the ai-sdlc workflow for FEDX-7265

# Pull Request

## Description
This PR extends `dependency_validator` to treat `hook/` as a public-facing directory alongside `lib/` and `bin/`. Dependencies used in hook scripts must now be declared as regular dependencies, not just dev-only dependencies, to ensure they're available at build/link time for consuming packages in production mode.

## Motivation
Dependencies imported inside a package's `hook/` directory run at build/link time (`dart build`, `flutter build`) via the package manager. If such a dependency is only declared as a `dev_dependency`, it won't be resolved when a consuming package installs in production mode, causing hook execution to fail at build time. `dependency_validator` previously only treated `lib/` and `bin/` as public-facing directories, so it did not flag dependencies used exclusively in `hook/` as needing promotion to a regular dependency.

## Changes
- Treats `hook/` as a public-facing directory alongside `lib/` and `bin/` for the purposes of dependency validation (`lib/src/constants.dart`, `lib/src/dependency_validator.dart`)
- Adds `publicDirNames` constant and a `publicDirsDescription()` helper to build human-readable messages (e.g. `lib/, bin/, or hook/`) used in warning output for missing, under-promoted, over-promoted, and unused-executable-dependency checks
- Updates all warning log messages in `dependency_validator.dart` to reference the dynamic public directories list instead of hardcoded `lib/` text
- Bumps package version to `6.0.0` and records this as a breaking change in `CHANGELOG.md`, since existing codebases with dev-only dependencies used in `hook/` will now fail validation
- Updates `README.md` to document that `hook/` is now considered public-facing and that hook-only dependencies must be regular dependencies (or explicitly `ignore`d/`exclude`d)
- Adds/updates tests in `test/executable_test.dart` and `test/utils_test.dart` covering: hook scripts using dev_dependencies (fails, unless ignored via config or embedded pubspec config), hook scripts using regular dependencies (passes), hook-only dependencies not being flagged as over-promoted, hook scripts using undeclared dependencies (fails), and the new `publicDirsDescription()` helper's output for both default and `and` conjunctions

## Testing
- Run the automated test suite with `dart test` (or `pub run test`) and confirm all tests pass
- Create a sample package with `hook/build.dart` using a dev_dependency and verify validation fails appropriately
- Move the dependency to regular dependencies and verify validation passes
- Test the ignore/exclude configuration to ensure hook dependencies can be explicitly excluded
- Verify documentation updates are accurate and complete

## Checklist
- [ ] Tests pass locally
- [ ] New/updated test cases cover hook/ scenarios
- [ ] Documentation (README.md) updated
- [ ] CHANGELOG.md updated with breaking change note
- [ ] Version bumped to 6.0.0
- [ ] Breaking change properly communicated

## Intent

This change extends dependency validation to treat the `hook/` directory as a public-facing directory alongside `lib/` and `bin/`, ensuring that dependencies used in build hooks are properly declared as regular dependencies rather than dev-only. It addresses a critical issue where hook dependencies declared only in dev_dependencies would fail at build time when consumed by other packages in production mode.

## How To QA

1. 1. Run 'dart test' or 'pub run test' and verify all tests pass, including new/updated cases in test/executable_test.dart and test/utils_test.dart
2. 2. Create a sample package with hook/build.dart importing a dev_dependency package. Run dependency_validator and verify it exits with code 1 and reports the dependency needs promotion, with message listing 'lib/, bin/, or hook/'
3. 3. Move the hook dependency to regular dependencies in pubspec.yaml and re-run dependency_validator. Verify it exits with code 0 and shows 'No dependency issues found!'
4. 4. Add the hook dependency to the ignore list in dart_dependency_validator.yaml while keeping it as dev_dependency, re-run, and verify validator passes with exit code 0
5. 5. Review README.md and CHANGELOG.md changes to confirm they accurately document the new behavior and breaking change for version 6.0.0
