### PR TITLE
FEDX-7266: Support glob patterns in dependency_validator workspace resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 - Added support for glob patterns in `workspace:` entries (for example
   `packages/*`). Only directories containing a `pubspec.yaml` are treated as
-  workspace members. (ref #176)
+  workspace members. A glob that matches no packages logs a warning. (ref #176)
+- Workspace members are now validated in sorted order (deduplicated across
+  overlapping entries) rather than in the order they are listed in `workspace:`.
+  This only affects the order of log output.
 
 # 5.0.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
-<!-- Add unreleased changes here -->
+
+- Added support for glob patterns in `workspace:` entries (for example
+  `packages/*`). Only directories containing a `pubspec.yaml` are treated as
+  workspace members. (ref #176)
 
 # 5.0.6
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ workspace:
 
 Glob patterns such as `packages/*` are supported. Only directories that contain
 a `pubspec.yaml` are treated as workspace members; other directories matched by
-the glob are ignored.
+the glob are ignored. A glob that matches no packages logs a warning.
+
+> **Note:** `dependency_validator` will expand glob entries regardless of your
+> SDK constraint, but pub itself only supports glob patterns in `workspace:` when
+> the root package's SDK constraint is `^3.11.0` or higher. On older SDKs, pub
+> treats the entry as a literal path and `pub get` will fail.
 
 and your sub-packages should have `resolution: workspace` in their `pubspec.yaml`s. For more information, see the linked documentation.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ This package supports [Pub Workspaces](https://dart.dev/tools/pub/workspaces), a
 workspace:
   - pkg1
   - pkg2
+  - packages/*
 ```
+
+Glob patterns such as `packages/*` are supported. Only directories that contain
+a `pubspec.yaml` are treated as workspace members; other directories matched by
+the glob are ignored.
 
 and your sub-packages should have `resolution: workspace` in their `pubspec.yaml`s. For more information, see the linked documentation.
 

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -58,7 +58,7 @@ Future<bool> checkPackage({required String root}) async {
       .map((s) {
         try {
           return makeGlob("$root/$s");
-        } catch (_, __) {
+        } catch (_) {
           logger.shout(yellow.wrap('invalid glob syntax: "$s"'));
           return null;
         }
@@ -80,14 +80,12 @@ Future<bool> checkPackage({required String root}) async {
   );
 
   List<String> workspaceMembers = const [];
+  var subResult = true;
   if (pubspec.isWorkspaceRoot) {
     final resolved = resolveWorkspaceMembers(root, pubspec.workspace ?? []);
     if (resolved == null) return false;
     workspaceMembers = resolved;
-  }
 
-  var subResult = true;
-  if (pubspec.isWorkspaceRoot) {
     logger.fine('In a workspace. Recursing through sub-packages...');
     for (final package in workspaceMembers) {
       subResult &= await checkPackage(root: p.join(root, package));
@@ -115,11 +113,13 @@ Future<bool> checkPackage({required String root}) async {
   );
 
   final nestedPackages = listNestedPackages(root);
-  final nestedPackageGlobs = [
-    for (final nested in nestedPackages)
-      makeGlob('${p.normalize(nested.path)}/**'),
+  final nestedPackagePaths = {
+    for (final nested in nestedPackages) p.normalize(nested.path),
     for (final subpackage in workspaceMembers)
-      makeGlob('${p.join(root, subpackage)}/**'),
+      p.normalize(p.join(root, subpackage)),
+  };
+  final nestedPackageGlobs = [
+    for (final path in nestedPackagePaths) makeGlob('$path/**'),
   ];
   logger.fine(
     'nested package globs:\n'

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -79,13 +79,17 @@ Future<bool> checkPackage({required String root}) async {
     sourceUrl: pubspecFile.uri,
   );
 
+  List<String> workspaceMembers = const [];
+  if (pubspec.isWorkspaceRoot) {
+    final resolved = resolveWorkspaceMembers(root, pubspec.workspace ?? []);
+    if (resolved == null) return false;
+    workspaceMembers = resolved;
+  }
+
   var subResult = true;
   if (pubspec.isWorkspaceRoot) {
     logger.fine('In a workspace. Recursing through sub-packages...');
-    for (final package in resolveWorkspaceMembers(
-      root,
-      pubspec.workspace ?? [],
-    )) {
+    for (final package in workspaceMembers) {
       subResult &= await checkPackage(root: p.join(root, package));
       logger.info('');
     }
@@ -160,11 +164,8 @@ Future<bool> checkPackage({required String root}) async {
   final publicDirGlobs = [for (final dir in publicDirs) makeGlob('$dir**')];
 
   final subpackageGlobs = [
-    for (final subpackage in resolveWorkspaceMembers(
-      root,
-      pubspec.workspace ?? [],
-    ))
-      makeGlob('$root/$subpackage**'),
+    for (final subpackage in workspaceMembers)
+      makeGlob('${p.join(root, subpackage)}/**'),
   ];
 
   logger.fine('subpackage globs: $subpackageGlobs');

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -82,8 +82,11 @@ Future<bool> checkPackage({required String root}) async {
   var subResult = true;
   if (pubspec.isWorkspaceRoot) {
     logger.fine('In a workspace. Recursing through sub-packages...');
-    for (final package in pubspec.workspace ?? []) {
-      subResult &= await checkPackage(root: '$root/$package');
+    for (final package in resolveWorkspaceMembers(
+      root,
+      pubspec.workspace ?? [],
+    )) {
+      subResult &= await checkPackage(root: p.join(root, package));
       logger.info('');
     }
   }
@@ -157,7 +160,10 @@ Future<bool> checkPackage({required String root}) async {
   final publicDirGlobs = [for (final dir in publicDirs) makeGlob('$dir**')];
 
   final subpackageGlobs = [
-    for (final subpackage in pubspec.workspace ?? [])
+    for (final subpackage in resolveWorkspaceMembers(
+      root,
+      pubspec.workspace ?? [],
+    ))
       makeGlob('$root/$subpackage**'),
   ];
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -227,8 +227,12 @@ String _normalizeWorkspaceMemberPath(String path) =>
 /// containing a pubspec.yaml file, matching pub's workspace resolution
 /// behavior.
 ///
+/// A glob pattern that matches no package directories logs a warning, since
+/// pub itself rejects such an entry and it usually indicates a typo.
+///
 /// Returns a sorted, deduplicated list with posix-normalized path separators.
-/// Returns `null` if any workspace path has invalid glob syntax.
+/// Returns `null` if any workspace path has invalid glob syntax or cannot be
+/// listed.
 List<String>? resolveWorkspaceMembers(
   String root,
   Iterable<String> workspacePaths,
@@ -236,22 +240,45 @@ List<String>? resolveWorkspaceMembers(
   final members = <String>{};
   for (final workspacePath in workspacePaths) {
     if (hasGlobWildcards(workspacePath)) {
+      final Glob glob;
       try {
-        final glob = makeGlob(workspacePath);
-        for (final entity in glob.listSync(root: root)) {
-          if (entity is! Directory) continue;
-          if (!File(p.join(entity.path, 'pubspec.yaml')).existsSync()) {
-            continue;
-          }
-          members.add(
-            _normalizeWorkspaceMemberPath(
-              p.relative(entity.path, from: root),
-            ),
-          );
-        }
+        glob = makeGlob(workspacePath);
       } on FormatException {
         logger.shout(yellow.wrap('invalid glob syntax: "$workspacePath"'));
         return null;
+      }
+
+      final List<FileSystemEntity> matches;
+      try {
+        matches = glob.listSync(root: root);
+      } on FileSystemException catch (e) {
+        logger.shout(
+          yellow.wrap(
+            'failed to list workspace glob "$workspacePath": ${e.message}'
+            '${e.path != null ? ' (${e.path})' : ''}',
+          ),
+        );
+        return null;
+      }
+
+      var matchedPackage = false;
+      for (final entity in matches) {
+        if (entity is! Directory) continue;
+        if (!File(p.join(entity.path, 'pubspec.yaml')).existsSync()) {
+          continue;
+        }
+        matchedPackage = true;
+        members.add(
+          _normalizeWorkspaceMemberPath(p.relative(entity.path, from: root)),
+        );
+      }
+      if (!matchedPackage) {
+        logger.warning(
+          yellow.wrap(
+            'No workspace packages matching "$workspacePath". '
+            'Check the pattern for typos.',
+          ),
+        );
       }
     } else {
       members.add(_normalizeWorkspaceMemberPath(workspacePath));

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -15,6 +15,7 @@
 import 'dart:io';
 
 import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
 import 'package:io/ansi.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:logging/logging.dart';
@@ -209,3 +210,33 @@ extension PubspecUtils on Pubspec {
 /// This function removes `./` paths and replaces all `\` with `/`.
 Glob makeGlob(String path) =>
     Glob(p.posix.normalize(path.replaceAll(r'\', '/')));
+
+/// Returns whether [path] contains glob wildcard syntax characters.
+bool hasGlobWildcards(String path) =>
+    path.contains('*') ||
+    path.contains('?') ||
+    path.contains('[') ||
+    path.contains('{');
+
+/// Resolves workspace member paths from [workspacePaths] relative to [root].
+///
+/// Glob patterns (for example `packages/*`) are expanded to directories
+/// containing a pubspec.yaml file, matching pub's workspace resolution
+/// behavior.
+Iterable<String> resolveWorkspaceMembers(
+  String root,
+  Iterable<String> workspacePaths,
+) sync* {
+  for (final workspacePath in workspacePaths) {
+    if (hasGlobWildcards(workspacePath)) {
+      final glob = makeGlob(workspacePath);
+      for (final entity in glob.listSync(root: root)) {
+        if (entity is! Directory) continue;
+        if (!File(p.join(entity.path, 'pubspec.yaml')).existsSync()) continue;
+        yield p.relative(entity.path, from: root);
+      }
+    } else {
+      yield workspacePath;
+    }
+  }
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -237,7 +237,9 @@ bool hasGlobWildcards(String path) =>
     path.contains('*') ||
     path.contains('?') ||
     path.contains('[') ||
-    path.contains('{');
+    path.contains(']') ||
+    path.contains('{') ||
+    path.contains('}');
 
 String _normalizeWorkspaceMemberPath(String path) =>
     p.posix.normalize(path.replaceAll(r'\', '/'));
@@ -252,12 +254,13 @@ String _normalizeWorkspaceMemberPath(String path) =>
 /// pub itself rejects such an entry and it usually indicates a typo.
 ///
 /// Returns a sorted, deduplicated list with posix-normalized path separators.
-/// Returns `null` if any workspace path has invalid glob syntax or cannot be
-/// listed.
+/// Returns `null` if any workspace path has invalid glob syntax, escapes the
+/// workspace root, or cannot be listed.
 List<String>? resolveWorkspaceMembers(
   String root,
   Iterable<String> workspacePaths,
 ) {
+  final canonicalRoot = p.canonicalize(root);
   final members = <String>{};
   for (final workspacePath in workspacePaths) {
     if (hasGlobWildcards(workspacePath)) {
@@ -265,19 +268,17 @@ List<String>? resolveWorkspaceMembers(
       try {
         glob = makeGlob(workspacePath);
       } on FormatException {
-        logger.shout(yellow.wrap('invalid glob syntax: "$workspacePath"'));
+        logger.shout('invalid glob syntax: "$workspacePath"');
         return null;
       }
 
       final List<FileSystemEntity> matches;
       try {
-        matches = glob.listSync(root: root);
+        matches = glob.listSync(root: root, followLinks: false);
       } on FileSystemException catch (e) {
         logger.shout(
-          yellow.wrap(
-            'failed to list workspace glob "$workspacePath": ${e.message}'
-            '${e.path != null ? ' (${e.path})' : ''}',
-          ),
+          'failed to list workspace glob "$workspacePath": ${e.message}'
+          '${e.path != null ? ' (${e.path})' : ''}',
         );
         return null;
       }
@@ -285,24 +286,41 @@ List<String>? resolveWorkspaceMembers(
       var matchedPackage = false;
       for (final entity in matches) {
         if (entity is! Directory) continue;
+        final canonicalEntity = p.canonicalize(entity.path);
+        if (!p.isWithin(canonicalRoot, canonicalEntity)) continue;
+
+        final relPath = _normalizeWorkspaceMemberPath(
+          p.relative(entity.path, from: root),
+        );
+        if (p.split(relPath).any((d) => d != '.' && d.startsWith('.'))) {
+          continue;
+        }
+
         if (!File(p.join(entity.path, 'pubspec.yaml')).existsSync()) {
           continue;
         }
         matchedPackage = true;
-        members.add(
-          _normalizeWorkspaceMemberPath(p.relative(entity.path, from: root)),
-        );
+        members.add(relPath);
       }
       if (!matchedPackage) {
         logger.warning(
-          yellow.wrap(
-            'No workspace packages matching "$workspacePath". '
-            'Check the pattern for typos.',
-          ),
+          'No workspace packages matching "$workspacePath". '
+          'Check the pattern for typos.',
         );
       }
     } else {
-      members.add(_normalizeWorkspaceMemberPath(workspacePath));
+      final normalized = _normalizeWorkspaceMemberPath(workspacePath);
+      final fullPath = p.normalize(
+        p.isAbsolute(normalized) ? normalized : p.join(root, normalized),
+      );
+      final canonicalPath = p.canonicalize(fullPath);
+      if (!p.isWithin(canonicalRoot, canonicalPath)) {
+        logger.shout(
+          'Workspace member "$workspacePath" must be in a subdirectory of the workspace root.',
+        );
+        return null;
+      }
+      members.add(normalized);
     }
   }
   return (members.toList()..sort());

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -218,25 +218,44 @@ bool hasGlobWildcards(String path) =>
     path.contains('[') ||
     path.contains('{');
 
+String _normalizeWorkspaceMemberPath(String path) =>
+    p.posix.normalize(path.replaceAll(r'\', '/'));
+
 /// Resolves workspace member paths from [workspacePaths] relative to [root].
 ///
 /// Glob patterns (for example `packages/*`) are expanded to directories
 /// containing a pubspec.yaml file, matching pub's workspace resolution
 /// behavior.
-Iterable<String> resolveWorkspaceMembers(
+///
+/// Returns a sorted, deduplicated list with posix-normalized path separators.
+/// Returns `null` if any workspace path has invalid glob syntax.
+List<String>? resolveWorkspaceMembers(
   String root,
   Iterable<String> workspacePaths,
-) sync* {
+) {
+  final members = <String>{};
   for (final workspacePath in workspacePaths) {
     if (hasGlobWildcards(workspacePath)) {
-      final glob = makeGlob(workspacePath);
-      for (final entity in glob.listSync(root: root)) {
-        if (entity is! Directory) continue;
-        if (!File(p.join(entity.path, 'pubspec.yaml')).existsSync()) continue;
-        yield p.relative(entity.path, from: root);
+      try {
+        final glob = makeGlob(workspacePath);
+        for (final entity in glob.listSync(root: root)) {
+          if (entity is! Directory) continue;
+          if (!File(p.join(entity.path, 'pubspec.yaml')).existsSync()) {
+            continue;
+          }
+          members.add(
+            _normalizeWorkspaceMemberPath(
+              p.relative(entity.path, from: root),
+            ),
+          );
+        }
+      } on FormatException {
+        logger.shout(yellow.wrap('invalid glob syntax: "$workspacePath"'));
+        return null;
       }
     } else {
-      yield workspacePath;
+      members.add(_normalizeWorkspaceMemberPath(workspacePath));
     }
   }
+  return (members.toList()..sort());
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:dependency_validator/src/dependency_validator.dart';
 import 'package:dependency_validator/src/pubspec_config.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
@@ -78,15 +79,17 @@ Future<void> checkWorkspace({
   DepValidatorConfig? subpackageConfig,
   Level logLevel = Level.OFF,
   Matcher matcher = isTrue,
+  List<String>? workspaceMembers,
+  String subpackagePath = 'subpackage',
 }) async {
   final workspacePubspec = Pubspec(
     'workspace',
     environment: requireDart36,
     dependencies: workspaceDeps,
-    workspace: ['subpackage'],
+    workspace: workspaceMembers ?? [subpackagePath],
   );
   final subpackagePubspec = Pubspec(
-    'subpackage',
+    p.basename(subpackagePath),
     environment: requireDart36,
     dependencies: subpackageDeps,
     resolution: 'workspace',
@@ -99,7 +102,7 @@ Future<void> checkWorkspace({
         'dart_dependency_validator.yaml',
         jsonEncode(workspaceConfig.toJson()),
       ),
-    d.dir('subpackage', [
+    d.dir(subpackagePath, [
       ...subpackage,
       d.file('pubspec.yaml', jsonEncode(subpackagePubspec.toJson())),
       if (subpackageConfig != null)

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -77,25 +77,43 @@ typedef WorkspaceSubpackage = ({
   DepValidatorConfig? config,
 });
 
-Future<void> checkWorkspace({
+/// Creates a workspace in the test sandbox and runs [checkPackage] on it.
+///
+/// By default the workspace has a single sub-package at `subpackage/`
+/// described by [subpackage], [subpackageDeps], and [subpackageConfig]. Pass
+/// [subpackages] instead to create several sub-packages at arbitrary paths;
+/// the single-sub-package parameters must then be omitted.
+///
+/// [workspaceMembers] overrides the root pubspec's `workspace:` list (for
+/// example to use glob patterns); it defaults to the sub-package paths.
+///
+/// Returns the log messages emitted at or above [logLevel] while validating.
+Future<List<String>> checkWorkspace({
   required Map<String, Dependency> workspaceDeps,
-  required Map<String, Dependency> subpackageDeps,
   required List<d.Descriptor> workspace,
-  required List<d.Descriptor> subpackage,
+  Map<String, Dependency>? subpackageDeps,
+  List<d.Descriptor>? subpackage,
   DepValidatorConfig? workspaceConfig,
   DepValidatorConfig? subpackageConfig,
   Level logLevel = Level.OFF,
   Matcher matcher = isTrue,
   List<String>? workspaceMembers,
-  String subpackagePath = 'subpackage',
   List<WorkspaceSubpackage>? subpackages,
 }) async {
+  if (subpackages != null) {
+    expect(
+      subpackage ?? subpackageDeps ?? subpackageConfig,
+      isNull,
+      reason: 'Pass either `subpackages` or the single-subpackage parameters '
+          '(`subpackage`, `subpackageDeps`, `subpackageConfig`), not both.',
+    );
+  }
   final resolvedSubpackages = subpackages ??
       [
         (
-          path: subpackagePath,
-          contents: subpackage,
-          deps: subpackageDeps,
+          path: 'subpackage',
+          contents: subpackage ?? const [],
+          deps: subpackageDeps ?? const {},
           config: subpackageConfig,
         ),
       ];
@@ -137,6 +155,14 @@ Future<void> checkWorkspace({
   ]);
   await dir.create();
   Logger.root.level = logLevel;
-  final result = await checkPackage(root: '${d.sandbox}/workspace');
-  expect(result, matcher);
+  final messages = <String>[];
+  final subscription =
+      Logger.root.onRecord.listen((record) => messages.add(record.message));
+  try {
+    final result = await checkPackage(root: '${d.sandbox}/workspace');
+    expect(result, matcher);
+  } finally {
+    await subscription.cancel();
+  }
+  return messages;
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -100,12 +100,13 @@ Future<List<String>> checkWorkspace({
   List<String>? workspaceMembers,
   List<WorkspaceSubpackage>? subpackages,
 }) async {
-  if (subpackages != null) {
-    expect(
-      subpackage ?? subpackageDeps ?? subpackageConfig,
-      isNull,
-      reason: 'Pass either `subpackages` or the single-subpackage parameters '
-          '(`subpackage`, `subpackageDeps`, `subpackageConfig`), not both.',
+  if (subpackages != null &&
+      (subpackage != null ||
+          subpackageDeps != null ||
+          subpackageConfig != null)) {
+    throw ArgumentError(
+      'Pass either `subpackages` or the single-subpackage parameters '
+      '(`subpackage`, `subpackageDeps`, `subpackageConfig`), not both.',
     );
   }
   final resolvedSubpackages = subpackages ??

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -70,6 +70,13 @@ final requireDart36 = {
   "sdk": VersionConstraint.compatibleWith(Version.parse('3.6.0')),
 };
 
+typedef WorkspaceSubpackage = ({
+  String path,
+  List<d.Descriptor> contents,
+  Map<String, Dependency> deps,
+  DepValidatorConfig? config,
+});
+
 Future<void> checkWorkspace({
   required Map<String, Dependency> workspaceDeps,
   required Map<String, Dependency> subpackageDeps,
@@ -81,18 +88,23 @@ Future<void> checkWorkspace({
   Matcher matcher = isTrue,
   List<String>? workspaceMembers,
   String subpackagePath = 'subpackage',
+  List<WorkspaceSubpackage>? subpackages,
 }) async {
+  final resolvedSubpackages = subpackages ??
+      [
+        (
+          path: subpackagePath,
+          contents: subpackage,
+          deps: subpackageDeps,
+          config: subpackageConfig,
+        ),
+      ];
   final workspacePubspec = Pubspec(
     'workspace',
     environment: requireDart36,
     dependencies: workspaceDeps,
-    workspace: workspaceMembers ?? [subpackagePath],
-  );
-  final subpackagePubspec = Pubspec(
-    p.basename(subpackagePath),
-    environment: requireDart36,
-    dependencies: subpackageDeps,
-    resolution: 'workspace',
+    workspace:
+        workspaceMembers ?? resolvedSubpackages.map((s) => s.path).toList(),
   );
   final dir = d.dir('workspace', [
     ...workspace,
@@ -102,15 +114,26 @@ Future<void> checkWorkspace({
         'dart_dependency_validator.yaml',
         jsonEncode(workspaceConfig.toJson()),
       ),
-    d.dir(subpackagePath, [
-      ...subpackage,
-      d.file('pubspec.yaml', jsonEncode(subpackagePubspec.toJson())),
-      if (subpackageConfig != null)
+    for (final subpackageSpec in resolvedSubpackages)
+      d.dir(subpackageSpec.path, [
+        ...subpackageSpec.contents,
         d.file(
-          'dart_dependency_validator.yaml',
-          jsonEncode(subpackageConfig.toJson()),
+          'pubspec.yaml',
+          jsonEncode(
+            Pubspec(
+              p.basename(subpackageSpec.path),
+              environment: requireDart36,
+              dependencies: subpackageSpec.deps,
+              resolution: 'workspace',
+            ).toJson(),
+          ),
         ),
-    ]),
+        if (subpackageSpec.config != null)
+          d.file(
+            'dart_dependency_validator.yaml',
+            jsonEncode(subpackageSpec.config!.toJson()),
+          ),
+      ]),
   ]);
   await dir.create();
   Logger.root.level = logLevel;

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -25,6 +25,8 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:dependency_validator/src/constants.dart';
 import 'package:dependency_validator/src/utils.dart';
 
+import 'utils.dart';
+
 void main() {
   group('getAnalysisOptionsIncludePackage', () {
     test('no analysis_options.yaml', () {
@@ -554,6 +556,66 @@ include: package:pedantic/analysis_options.1.8.0.yaml
       );
     });
 
+    test('ignores matches in hidden directories', () async {
+      await d.dir('root', [
+        d.dir('packages', [
+          d.dir('pkg_a', [
+            d.file('pubspec.yaml', 'name: pkg_a\n'),
+          ]),
+          d.dir('.hidden_pkg', [
+            d.file('pubspec.yaml', 'name: hidden_pkg\n'),
+          ]),
+        ]),
+        d.dir('.dart_tool', [
+          d.dir('tool_pkg', [
+            d.file('pubspec.yaml', 'name: tool_pkg\n'),
+          ]),
+        ]),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*', '*/*']),
+        ['packages/pkg_a'],
+      );
+    });
+
+    test('returns null when literal path is the workspace root itself', () async {
+      await d.dir('root', [
+        d.file('pubspec.yaml', 'name: root\n'),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['.']),
+        isNull,
+      );
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['./']),
+        isNull,
+      );
+    });
+
+    test('returns null when literal path escapes the workspace root', () async {
+      await d.dir('root', [
+        d.file('pubspec.yaml', 'name: root\n'),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['../outside']),
+        isNull,
+      );
+    });
+
+    test('returns null when literal path is an absolute path outside root', () async {
+      await d.dir('root', [
+        d.file('pubspec.yaml', 'name: root\n'),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['/some/absolute/path']),
+        isNull,
+      );
+    });
+
     group('logging', () {
       late List<LogRecord> records;
       late StreamSubscription<LogRecord> subscription;
@@ -643,10 +705,14 @@ include: package:pedantic/analysis_options.1.8.0.yaml
       expect(hasGlobWildcards('apps/nested/pkg?'), isTrue);
       expect(hasGlobWildcards('packages/[abc]'), isTrue);
       expect(hasGlobWildcards('packages/{a,b}'), isTrue);
+      expect(hasGlobWildcards('packages/pkg]'), isTrue);
+      expect(hasGlobWildcards('packages/pkg}'), isTrue);
     });
 
     test('returns false for literal paths', () {
       expect(hasGlobWildcards('packages/subpackage'), isFalse);
+      expect(hasGlobWildcards('packages/sub-package'), isFalse);
+      expect(hasGlobWildcards('packages/sub_package'), isFalse);
     });
   });
 
@@ -697,5 +763,22 @@ include: package:pedantic/analysis_options.1.8.0.yaml
         p.join('pkgs', 'nested_sub'),
       ]);
     });
+  });
+
+  group('checkWorkspace', () {
+    test(
+      'throws ArgumentError when mixing subpackages and subpackage params',
+      () async {
+        expect(
+          () => checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            subpackages: [],
+            subpackage: [],
+          ),
+          throwsArgumentError,
+        );
+      },
+    );
   });
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -459,7 +459,7 @@ include: package:pedantic/analysis_options.1.8.0.yaml
       ]).create();
 
       expect(
-        resolveWorkspaceMembers('${d.sandbox}/root', ['subpackage']).toList(),
+        resolveWorkspaceMembers('${d.sandbox}/root', ['subpackage']),
         ['subpackage'],
       );
     });
@@ -480,8 +480,7 @@ include: package:pedantic/analysis_options.1.8.0.yaml
       ]).create();
 
       expect(
-        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']).toList()
-          ..sort(),
+        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']),
         ['packages/pkg_a', 'packages/pkg_b'],
       );
     });
@@ -497,8 +496,56 @@ include: package:pedantic/analysis_options.1.8.0.yaml
       ]).create();
 
       expect(
-        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']).toList(),
+        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']),
         ['packages/pkg_a'],
+      );
+    });
+
+    test('deduplicates overlapping literal and glob paths', () async {
+      await d.dir('root', [
+        d.dir('packages', [
+          d.dir('foo', [
+            d.file('pubspec.yaml', 'name: foo\n'),
+          ]),
+          d.dir('bar', [
+            d.file('pubspec.yaml', 'name: bar\n'),
+          ]),
+        ]),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', [
+          'packages/*',
+          'packages/foo',
+        ]),
+        ['packages/bar', 'packages/foo'],
+      );
+    });
+
+    test('returns sorted results independent of filesystem order', () async {
+      await d.dir('root', [
+        d.dir('packages', [
+          d.dir('zebra', [
+            d.file('pubspec.yaml', 'name: zebra\n'),
+          ]),
+          d.dir('alpha', [
+            d.file('pubspec.yaml', 'name: alpha\n'),
+          ]),
+        ]),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']),
+        ['packages/alpha', 'packages/zebra'],
+      );
+    });
+
+    test('returns null for invalid glob syntax', () async {
+      await d.dir('root', []).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/[a']),
+        isNull,
       );
     });
   });

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -449,4 +449,70 @@ include: package:pedantic/analysis_options.1.8.0.yaml
       });
     });
   });
+
+  group('resolveWorkspaceMembers', () {
+    test('returns literal workspace paths unchanged', () async {
+      await d.dir('root', [
+        d.dir('subpackage', [
+          d.file('pubspec.yaml', 'name: subpackage\n'),
+        ]),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['subpackage']).toList(),
+        ['subpackage'],
+      );
+    });
+
+    test('expands glob patterns to directories with pubspec.yaml', () async {
+      await d.dir('root', [
+        d.dir('packages', [
+          d.dir('pkg_a', [
+            d.file('pubspec.yaml', 'name: pkg_a\n'),
+          ]),
+          d.dir('pkg_b', [
+            d.file('pubspec.yaml', 'name: pkg_b\n'),
+          ]),
+          d.dir('not_a_package', [
+            d.file('README.md', ''),
+          ]),
+        ]),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']).toList()
+          ..sort(),
+        ['packages/pkg_a', 'packages/pkg_b'],
+      );
+    });
+
+    test('ignores glob matches without pubspec.yaml', () async {
+      await d.dir('root', [
+        d.dir('packages', [
+          d.dir('pkg_a', [
+            d.file('pubspec.yaml', 'name: pkg_a\n'),
+          ]),
+          d.dir('empty_dir', []),
+        ]),
+      ]).create();
+
+      expect(
+        resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']).toList(),
+        ['packages/pkg_a'],
+      );
+    });
+  });
+
+  group('hasGlobWildcards', () {
+    test('detects glob syntax', () {
+      expect(hasGlobWildcards('packages/*'), isTrue);
+      expect(hasGlobWildcards('apps/nested/pkg?'), isTrue);
+      expect(hasGlobWildcards('packages/[abc]'), isTrue);
+      expect(hasGlobWildcards('packages/{a,b}'), isTrue);
+    });
+
+    test('returns false for literal paths', () {
+      expect(hasGlobWildcards('packages/subpackage'), isFalse);
+    });
+  });
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -579,7 +579,8 @@ include: package:pedantic/analysis_options.1.8.0.yaml
       );
     });
 
-    test('returns null when literal path is the workspace root itself', () async {
+    test('returns null when literal path is the workspace root itself',
+        () async {
       await d.dir('root', [
         d.file('pubspec.yaml', 'name: root\n'),
       ]).create();
@@ -605,7 +606,8 @@ include: package:pedantic/analysis_options.1.8.0.yaml
       );
     });
 
-    test('returns null when literal path is an absolute path outside root', () async {
+    test('returns null when literal path is an absolute path outside root',
+        () async {
       await d.dir('root', [
         d.file('pubspec.yaml', 'name: root\n'),
       ]).create();

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 @TestOn('vm')
+import 'dart:async';
+import 'dart:io';
+
+import 'package:logging/logging.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -546,6 +550,88 @@ include: package:pedantic/analysis_options.1.8.0.yaml
       expect(
         resolveWorkspaceMembers('${d.sandbox}/root', ['packages/[a']),
         isNull,
+      );
+    });
+
+    group('logging', () {
+      late List<LogRecord> records;
+      late StreamSubscription<LogRecord> subscription;
+
+      setUp(() {
+        records = [];
+        Logger.root.level = Level.ALL;
+        subscription = Logger.root.onRecord.listen(records.add);
+      });
+
+      tearDown(() => subscription.cancel());
+
+      test('warns when a glob matches no package directories', () async {
+        await d.dir('root', [
+          d.dir('packages', [
+            d.dir('not_a_package', [d.file('README.md', '')]),
+          ]),
+        ]).create();
+
+        expect(
+          resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']),
+          isEmpty,
+        );
+        expect(
+          records.where((r) => r.level == Level.WARNING).map((r) => r.message),
+          [contains('No workspace packages matching "packages/*"')],
+        );
+      });
+
+      test('warns when a glob matches nothing at all', () async {
+        await d.dir('root', []).create();
+
+        expect(
+          resolveWorkspaceMembers('${d.sandbox}/root', ['missing/*']),
+          isEmpty,
+        );
+        expect(
+          records.map((r) => r.message),
+          [contains('No workspace packages matching "missing/*"')],
+        );
+      });
+
+      test('does not warn when a glob matches a package', () async {
+        await d.dir('root', [
+          d.dir('packages', [
+            d.dir('pkg_a', [d.file('pubspec.yaml', 'name: pkg_a\n')]),
+          ]),
+        ]).create();
+
+        expect(
+          resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']),
+          ['packages/pkg_a'],
+        );
+        expect(records, isEmpty);
+      });
+
+      test(
+        'returns null and shouts when a glob directory cannot be listed',
+        () async {
+          await d.dir('root', [
+            d.dir('packages', [
+              d.dir('pkg_a', [d.file('pubspec.yaml', 'name: pkg_a\n')]),
+            ]),
+          ]).create();
+          final packagesDir = Directory('${d.sandbox}/root/packages');
+          await Process.run('chmod', ['000', packagesDir.path]);
+          addTearDown(() => Process.run('chmod', ['755', packagesDir.path]));
+
+          expect(
+            resolveWorkspaceMembers('${d.sandbox}/root', ['packages/*']),
+            isNull,
+          );
+          expect(
+            records.where((r) => r.level == Level.SHOUT).map((r) => r.message),
+            [contains('failed to list workspace glob "packages/*"')],
+          );
+        },
+        // Relies on POSIX permissions being enforced for the current user.
+        skip: Platform.isWindows || Platform.environment['USER'] == 'root',
       );
     });
   });

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -277,5 +277,37 @@ void main() => group('Workspaces', () {
 
           expect(logs, contains(contains('invalid glob syntax')));
         });
+
+        test('fails when a workspace member points to workspace root itself', () async {
+          final logs = await checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            workspaceMembers: ['.'],
+            subpackages: [],
+            logLevel: Level.SHOUT,
+            matcher: isFalse,
+          );
+
+          expect(
+            logs,
+            contains(contains('must be in a subdirectory of the workspace root')),
+          );
+        });
+
+        test('fails when a workspace member escapes the workspace root', () async {
+          final logs = await checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            workspaceMembers: ['../outside'],
+            subpackages: [],
+            logLevel: Level.SHOUT,
+            matcher: isFalse,
+          );
+
+          expect(
+            logs,
+            contains(contains('must be in a subdirectory of the workspace root')),
+          );
+        });
       });
     });

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -149,4 +149,31 @@ void main() => group('Workspaces', () {
           ),
         );
       });
+
+      group('glob workspace patterns', () {
+        test(
+          'resolves packages/* to workspace members',
+          () => checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            subpackage: usesHttp,
+            subpackageDeps: dependsOnHttp,
+            workspaceMembers: ['packages/*'],
+            subpackagePath: 'packages/subpackage',
+          ),
+        );
+
+        test(
+          'validates each glob-matched subpackage',
+          () => checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            subpackage: usesHttp,
+            subpackageDeps: {},
+            workspaceMembers: ['packages/*'],
+            subpackagePath: 'packages/subpackage',
+            matcher: isFalse,
+          ),
+        );
+      });
     });

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -278,7 +278,8 @@ void main() => group('Workspaces', () {
           expect(logs, contains(contains('invalid glob syntax')));
         });
 
-        test('fails when a workspace member points to workspace root itself', () async {
+        test('fails when a workspace member points to workspace root itself',
+            () async {
           final logs = await checkWorkspace(
             workspace: [],
             workspaceDeps: {},
@@ -290,11 +291,13 @@ void main() => group('Workspaces', () {
 
           expect(
             logs,
-            contains(contains('must be in a subdirectory of the workspace root')),
+            contains(
+                contains('must be in a subdirectory of the workspace root')),
           );
         });
 
-        test('fails when a workspace member escapes the workspace root', () async {
+        test('fails when a workspace member escapes the workspace root',
+            () async {
           final logs = await checkWorkspace(
             workspace: [],
             workspaceDeps: {},
@@ -306,7 +309,8 @@ void main() => group('Workspaces', () {
 
           expect(
             logs,
-            contains(contains('must be in a subdirectory of the workspace root')),
+            contains(
+                contains('must be in a subdirectory of the workspace root')),
           );
         });
       });

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -151,19 +151,25 @@ void main() => group('Workspaces', () {
       });
 
       group('glob workspace patterns', () {
-        test(
-          'resolves packages/* to workspace members',
-          () => checkWorkspace(
-            workspace: [
-              d.dir('packages', [
-                d.dir('not_a_package', [
-                  d.file('README.md', ''),
-                ]),
-              ]),
-            ],
+        /// A `packages/` directory containing a non-package sibling that a
+        /// `packages/*` glob must skip.
+        final packagesDirWithNonPackage = [
+          d.dir('packages', [
+            d.dir('not_a_package', [
+              d.file('README.md', ''),
+            ]),
+          ]),
+        ];
+
+        /// Returns how many times [name] was validated according to [logs].
+        int timesValidated(List<String> logs, String name) => logs
+            .where((m) => m == 'Validating dependencies for $name...')
+            .length;
+
+        test('resolves packages/* to workspace members', () async {
+          final logs = await checkWorkspace(
+            workspace: packagesDirWithNonPackage,
             workspaceDeps: {},
-            subpackage: [],
-            subpackageDeps: {},
             workspaceMembers: ['packages/*'],
             subpackages: [
               (
@@ -179,22 +185,19 @@ void main() => group('Workspaces', () {
                 config: null,
               ),
             ],
-          ),
-        );
+            logLevel: Level.INFO,
+          );
 
-        test(
-          'validates each glob-matched subpackage',
-          () => checkWorkspace(
-            workspace: [
-              d.dir('packages', [
-                d.dir('not_a_package', [
-                  d.file('README.md', ''),
-                ]),
-              ]),
-            ],
+          expect(timesValidated(logs, 'pkg_a'), 1);
+          expect(timesValidated(logs, 'pkg_b'), 1);
+          expect(timesValidated(logs, 'workspace'), 1);
+          expect(logs, isNot(contains(contains('not_a_package'))));
+        });
+
+        test('validates each glob-matched subpackage', () async {
+          final logs = await checkWorkspace(
+            workspace: packagesDirWithNonPackage,
             workspaceDeps: {},
-            subpackage: [],
-            subpackageDeps: {},
             workspaceMembers: ['packages/*'],
             subpackages: [
               (
@@ -210,17 +213,20 @@ void main() => group('Workspaces', () {
                 config: null,
               ),
             ],
+            logLevel: Level.INFO,
             matcher: isFalse,
-          ),
-        );
+          );
 
-        test(
-          'supports mixed literal and glob workspace entries',
-          () => checkWorkspace(
+          expect(timesValidated(logs, 'pkg_a'), 1);
+          expect(timesValidated(logs, 'pkg_b'), 1);
+          // The missing dependency is reported for pkg_b, not pkg_a.
+          expect(logs, contains(contains('not dependencies')));
+        });
+
+        test('supports mixed literal and glob workspace entries', () async {
+          final logs = await checkWorkspace(
             workspace: [],
             workspaceDeps: {},
-            subpackage: [],
-            subpackageDeps: {},
             workspaceMembers: ['packages/foo', 'packages/*'],
             subpackages: [
               (
@@ -236,7 +242,40 @@ void main() => group('Workspaces', () {
                 config: null,
               ),
             ],
-          ),
-        );
+            logLevel: Level.INFO,
+          );
+
+          // `packages/foo` is matched by both entries but validated once.
+          expect(timesValidated(logs, 'foo'), 1);
+          expect(timesValidated(logs, 'bar'), 1);
+        });
+
+        test('warns when a glob matches no packages', () async {
+          final logs = await checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            workspaceMembers: ['pacakges/*'],
+            subpackages: [],
+            logLevel: Level.WARNING,
+          );
+
+          expect(
+            logs,
+            contains(contains('No workspace packages matching "pacakges/*"')),
+          );
+        });
+
+        test('fails on invalid glob syntax', () async {
+          final logs = await checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            workspaceMembers: ['packages/[a'],
+            subpackages: [],
+            logLevel: Level.WARNING,
+            matcher: isFalse,
+          );
+
+          expect(logs, contains(contains('invalid glob syntax')));
+        });
       });
     });

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -154,25 +154,88 @@ void main() => group('Workspaces', () {
         test(
           'resolves packages/* to workspace members',
           () => checkWorkspace(
-            workspace: [],
+            workspace: [
+              d.dir('packages', [
+                d.dir('not_a_package', [
+                  d.file('README.md', ''),
+                ]),
+              ]),
+            ],
             workspaceDeps: {},
-            subpackage: usesHttp,
-            subpackageDeps: dependsOnHttp,
+            subpackage: [],
+            subpackageDeps: {},
             workspaceMembers: ['packages/*'],
-            subpackagePath: 'packages/subpackage',
+            subpackages: [
+              (
+                path: 'packages/pkg_a',
+                contents: usesHttp,
+                deps: dependsOnHttp,
+                config: null,
+              ),
+              (
+                path: 'packages/pkg_b',
+                contents: usesMeta,
+                deps: dependsOnMeta,
+                config: null,
+              ),
+            ],
           ),
         );
 
         test(
           'validates each glob-matched subpackage',
           () => checkWorkspace(
-            workspace: [],
+            workspace: [
+              d.dir('packages', [
+                d.dir('not_a_package', [
+                  d.file('README.md', ''),
+                ]),
+              ]),
+            ],
             workspaceDeps: {},
-            subpackage: usesHttp,
+            subpackage: [],
             subpackageDeps: {},
             workspaceMembers: ['packages/*'],
-            subpackagePath: 'packages/subpackage',
+            subpackages: [
+              (
+                path: 'packages/pkg_a',
+                contents: usesHttp,
+                deps: dependsOnHttp,
+                config: null,
+              ),
+              (
+                path: 'packages/pkg_b',
+                contents: usesHttp,
+                deps: {},
+                config: null,
+              ),
+            ],
             matcher: isFalse,
+          ),
+        );
+
+        test(
+          'supports mixed literal and glob workspace entries',
+          () => checkWorkspace(
+            workspace: [],
+            workspaceDeps: {},
+            subpackage: [],
+            subpackageDeps: {},
+            workspaceMembers: ['packages/foo', 'packages/*'],
+            subpackages: [
+              (
+                path: 'packages/foo',
+                contents: usesHttp,
+                deps: dependsOnHttp,
+                config: null,
+              ),
+              (
+                path: 'packages/bar',
+                contents: usesMeta,
+                deps: dependsOnMeta,
+                config: null,
+              ),
+            ],
           ),
         );
       });


### PR DESCRIPTION
Opened by Dustin Pauze with the ai-sdlc workflow for FEDX-7266

## Motivation
Flutter/Dart pub workspaces support glob patterns for defining workspace members (e.g. `packages/*`), but `dependency_validator` only handled literal paths in `workspace:` entries. This meant any workspace configuration using glob patterns would fail to have its sub-packages resolved and validated correctly. (ref: Workiva/dependency_validator#176)

## Changes
- Added `resolveWorkspaceMembers` and `hasGlobWildcards` helpers in `lib/src/utils.dart` to expand glob patterns in `workspace:` entries into concrete sub-package directories, filtering to directories that contain a `pubspec.yaml` (matching pub's own workspace resolution behavior).
- Updated `checkPackage` in `lib/src/dependency_validator.dart` to resolve workspace members via the new helper before recursing into sub-packages and building subpackage globs, and to fail gracefully (return `false`) on invalid glob syntax.
- Updated `README.md` and `CHANGELOG.md` to document glob pattern support in workspace configuration.
- Extended the `checkWorkspace` test helper (`test/utils.dart`) to support multiple sub-packages with distinct paths/contents/deps/config, and added unit tests (`test/utils_test.dart`) and integration tests (`test/workspace_test.dart`) covering literal paths, glob expansion, filtering non-package directories, deduplication, sort order, invalid glob syntax, and mixed literal/glob workspace entries.

## Testing/QA Instructions
- Run `dart test` and confirm all tests pass, including the new `resolveWorkspaceMembers`/`hasGlobWildcards` unit tests and the glob workspace pattern integration tests.
- Manually verify against a workspace using `workspace: - packages/*` that only directories with a `pubspec.yaml` are validated as sub-packages, that dependency issues in glob-matched sub-packages are still detected, and that invalid glob syntax produces a warning rather than a crash.

- [ ] I have updated the CHANGELOG.md
- [ ] I have added/updated tests for this change
- [ ] I have verified this change manually

## Intent

dependency_validator didn't support glob patterns (e.g. `packages/*`) in `workspace:` entries, even though Dart pub workspaces support them. This change adds glob expansion for workspace member resolution so `dependency_validator` matches pub's actual workspace resolution behavior, enabling proper validation of sub-packages defined via glob patterns.

## How To QA

1. Run the full test suite with `dart test` and confirm all tests pass, including new resolveWorkspaceMembers, hasGlobWildcards, and glob workspace pattern tests in test/utils_test.dart and test/workspace_test.dart
2. Create a test workspace with `workspace: - packages/*` in pubspec.yaml and multiple sub-packages in packages/ directory (including one directory without pubspec.yaml). Run dependency_validator from workspace root and confirm it recurses into real sub-packages but skips non-package directories
3. In the same workspace, introduce an unused or missing dependency in a glob-matched sub-package and verify dependency_validator reports the issue for that specific sub-package
4. Test with a malformed glob pattern (e.g. `packages/[a`) and confirm the tool logs a warning about invalid syntax and does not crash
5. Verify a workspace with mixed literal and glob entries (e.g. `packages/foo` and `packages/*`) resolves without duplicate validation of packages/foo
