### PR TITLE
Fix failing tests and version solving in test fixtures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,6 @@ jobs:
       sdk: 3.7.2 # mirrors .tool-versions
 
   unit-tests:
-    uses: Workiva/gha-dart-oss/.github/workflows/test-unit.yaml@v0.1.14
+    uses: Workiva/gha-dart-oss/.github/workflows/test-unit.yaml@rob/fix-skipped-tests-fallback
     with:
       sdk: 3.7.2 # mirrors .tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   newest one the analyzer knows about, which may be unreleased and reject
   valid code
 
+- Allow up to analyzer 14
+
+- Fix warning when `analyzer` is depended on but not used so that it is still
+  emitted when `analyzer` is in the `ignore` list.
+
 # 5.0.6
 
 - Allow up to analyzer 13

--- a/lib/src/dependency_validator.dart
+++ b/lib/src/dependency_validator.dart
@@ -315,7 +315,7 @@ Future<bool> checkPackage({required String root}) async {
   }
 
   // Packages that are not used anywhere but are dependencies.
-  final unusedDependencies =
+  final rawUnusedDependencies =
       // Start with all explicitly declared dependencies
       deps
           .union(devDeps)
@@ -323,8 +323,9 @@ Future<bool> checkPackage({required String root}) async {
           .difference(packagesUsedInPublicFiles)
           .difference(packagesUsedOutsidePublicDirs)
         // Remove this package, since we know they're using our executable
-        ..remove(dependencyValidatorPackageName)
-        ..removeAll(ignoredPackages);
+        ..remove(dependencyValidatorPackageName);
+  final unusedDependencies = rawUnusedDependencies.toSet()
+    ..removeAll(ignoredPackages);
 
   final packageConfig = await findPackageConfig(Directory.current);
   if (packageConfig == null) {
@@ -405,7 +406,7 @@ Future<bool> checkPackage({required String root}) async {
   );
   unusedDependencies.removeAll(packagesWithExecutables);
 
-  if (unusedDependencies.contains('analyzer')) {
+  if (rawUnusedDependencies.contains('analyzer')) {
     logger.warning(
       yellow.wrap(
         'You do not need to depend on `analyzer` to run the Dart analyzer.\n'

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -335,9 +335,9 @@ void main() {
     test('passes when dependencies not used provide executables', () async {
       result = await checkProject(
         devDependencies: {
-          "build_runner": hostedCompatibleWith('2.3.3'),
+          "build_runner": hostedAny,
           'coverage': hostedAny,
-          'dart_style': hostedCompatibleWith('2.3.2'),
+          'dart_style': hostedAny,
         },
         project: [
           d.dir('lib', [d.file('main.dart', 'book fake = true;')]),
@@ -353,9 +353,9 @@ void main() {
       () async {
         result = await checkProject(
           dependencies: {
-            "build_runner": hostedCompatibleWith('2.3.3'),
+            "build_runner": hostedAny,
             "coverage": hostedAny,
-            "dart_style": hostedCompatibleWith('2.3.2'),
+            "dart_style": hostedAny,
           },
           project: [
             d.dir('lib', [d.file('main.dart', 'bool fake = true;')]),
@@ -377,9 +377,9 @@ void main() {
       () async {
         result = await checkProject(
           devDependencies: {
-            'build_test': hostedCompatibleWith('2.0.1'),
-            'build_vm_compilers': hostedCompatibleWith('1.0.3'),
-            'build_web_compilers': hostedCompatibleWith('3.2.7'),
+            'build_test': hostedAny,
+            'json_serializable': hostedAny,
+            'build_web_compilers': hostedAny,
           },
           project: [
             d.dir('lib', [d.file('main.dart', 'book fake = true;')]),


### PR DESCRIPTION
## Motivation
Several unit tests in `executable_test.dart` were failing:
1. The `analyzer` warning test failed because `ignoredPackages` was subtracted from `unusedDependencies` before checking if `analyzer` was depended on, causing the warning to be skipped when `analyzer` was ignored.
2. Tests asserting executable dependencies and auto-applied builders were failing pub version solving due to rigid version constraints (`dart_style: ^2.3.2`, `build_runner: ^2.3.3`, `build_vm_compilers: ^1.0.3`) incompatible with `analyzer >=7.1.0 <15.0.0`.

## Changes
- In `lib/src/dependency_validator.dart`, maintain `rawUnusedDependencies` before stripping `ignoredPackages` so the warning for depending on `analyzer` without using it is still emitted when `analyzer` is in `ignoredPackages`.
- In `test/executable_test.dart`, relax `build_runner`, `coverage`, `dart_style`, `build_test`, and `build_web_compilers` to `hostedAny` in tests checking executables/builders, and replace obsolete `build_vm_compilers` with `json_serializable` (which provides an auto-applied builder).
- Update CI workflow test-unit action reference.

## Testing/QA Instructions
- Run `dart test` to confirm all 97 tests pass.

Made with [Cursor](https://cursor.com)